### PR TITLE
Add support for auto-reporting of navigation solutions using UBX_NAV_PVT

### DIFF
--- a/examples/Example12_FactoryDefault2/Example12_FactoryDefault2.ino
+++ b/examples/Example12_FactoryDefault2/Example12_FactoryDefault2.ino
@@ -1,0 +1,60 @@
+/*
+  Test baud rate changes on serial, factory reset, and hard reset.
+  By: Thorsten von Eicken
+  Date: January 29rd, 2019
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  This example shows how to reset the U-Blox module to factory defaults.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  ZED-F9P RTK2: https://www.sparkfun.com/products/15136
+  NEO-M8P RTK: https://www.sparkfun.com/products/15005
+  SAM-M8Q: https://www.sparkfun.com/products/15106
+
+  Hardware Connections:
+  Connect the U-Blox serial port to Serial1
+  If you're using an Uno or don't have a 2nd serial port (Serial1), consider using software serial
+  Open the serial monitor at 115200 baud to see the output
+*/
+
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+SFE_UBLOX_GPS myGPS;
+
+int state = 0; // steps through auto-baud, reset, etc states
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); //Wait for user to open terminal
+  Serial.println("SparkFun Ublox Example");
+
+  Wire.begin();
+
+  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  while (Serial.available()) Serial.read(); //Trash any incoming chars
+  Serial.println("Press a key to reset module to factory defaults");
+  while (Serial.available() == false) ; //Wait for user to send character
+
+  myGPS.factoryReset();
+
+  if (myGPS.begin() == false) //Attempt to re-connect
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  Serial.println("Unit has now been factory reset. Freezing...");
+  while(1);
+}
+
+void loop()
+{
+
+}

--- a/examples/Example13_AutoPVT/Example13_AutoPVT.ino
+++ b/examples/Example13_AutoPVT/Example13_AutoPVT.ino
@@ -1,0 +1,84 @@
+/*
+  Configuring the GPS to automatically send position reports over I2C
+  By: Nathan Seidle
+  SparkFun Electronics
+  Date: January 3rd, 2019
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  This example shows how to configure the U-Blox GPS the send navigation reports automatically
+  and retrieving the latest one via getPVT. This eliminates the blocking in getPVT while the GPS
+  produces a fresh navigation solution at the expense of returning a slighly old solution.
+
+  This can be used over serial or over I2C, this example shows the I2C use. With serial the GPS
+  simply outputs the UBX_NAV_PVT packet. With I2C it queues it into its internal I2C buffer (4KB in
+  size?) where it can be retrieved in the next I2C poll.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  ZED-F9P RTK2: https://www.sparkfun.com/products/15136
+  NEO-M8P RTK: https://www.sparkfun.com/products/15005
+  SAM-M8Q: https://www.sparkfun.com/products/15106
+
+  Hardware Connections:
+  Plug a Qwiic cable into the GPS and a BlackBoard
+  If you don't have a platform with a Qwiic connection use the SparkFun Qwiic Breadboard Jumper (https://www.sparkfun.com/products/14425)
+  Open the serial monitor at 115200 baud to see the output
+*/
+
+#include <Particle.h>
+#include <Wire.h> //Needed for I2C to GPS
+
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+SFE_UBLOX_GPS myGPS;
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); //Wait for user to open terminal
+  Serial.println("SparkFun Ublox Example");
+
+  Wire.begin();
+
+  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  myGPS.setI2COutput(COM_TYPE_UBX); //Set the I2C port to output UBX only (turn off NMEA noise)
+  myGPS.setNavigationFrequency(2); //Produce two solutions per second
+  myGPS.setAutoPVT(true); //Tell the GPS to "send" each solution
+  myGPS.saveConfiguration(); //Save the current settings to flash and BBR
+}
+
+void loop()
+{
+    // Calling getPVT returns true if there actually is a fresh navigation solution available.
+    if (myGPS.getPVT())
+    {
+        Serial.println();
+        long latitude = myGPS.getLatitude();
+        Serial.print(F("Lat: "));
+        Serial.print(latitude);
+
+        long longitude = myGPS.getLongitude();
+        Serial.print(F(" Long: "));
+        Serial.print(longitude);
+        Serial.print(F(" (degrees * 10^-7)"));
+
+        long altitude = myGPS.getAltitude();
+        Serial.print(F(" Alt: "));
+        Serial.print(altitude);
+        Serial.print(F(" (mm)"));
+
+        byte SIV = myGPS.getSIV();
+        Serial.print(F(" SIV: "));
+        Serial.print(SIV);
+
+        Serial.println();
+    } else {
+        Serial.print(".");
+        delay(50);
+    }
+}

--- a/examples/Example13_AutoPVT/Example13_AutoPVT.ino
+++ b/examples/Example13_AutoPVT/Example13_AutoPVT.ino
@@ -26,7 +26,6 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include <Particle.h>
 #include <Wire.h> //Needed for I2C to GPS
 
 #include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
@@ -54,31 +53,31 @@ void setup()
 
 void loop()
 {
-    // Calling getPVT returns true if there actually is a fresh navigation solution available.
-    if (myGPS.getPVT())
-    {
-        Serial.println();
-        long latitude = myGPS.getLatitude();
-        Serial.print(F("Lat: "));
-        Serial.print(latitude);
+  // Calling getPVT returns true if there actually is a fresh navigation solution available.
+  if (myGPS.getPVT())
+  {
+    Serial.println();
+    long latitude = myGPS.getLatitude();
+    Serial.print(F("Lat: "));
+    Serial.print(latitude);
 
-        long longitude = myGPS.getLongitude();
-        Serial.print(F(" Long: "));
-        Serial.print(longitude);
-        Serial.print(F(" (degrees * 10^-7)"));
+    long longitude = myGPS.getLongitude();
+    Serial.print(F(" Long: "));
+    Serial.print(longitude);
+    Serial.print(F(" (degrees * 10^-7)"));
 
-        long altitude = myGPS.getAltitude();
-        Serial.print(F(" Alt: "));
-        Serial.print(altitude);
-        Serial.print(F(" (mm)"));
+    long altitude = myGPS.getAltitude();
+    Serial.print(F(" Alt: "));
+    Serial.print(altitude);
+    Serial.print(F(" (mm)"));
 
-        byte SIV = myGPS.getSIV();
-        Serial.print(F(" SIV: "));
-        Serial.print(SIV);
+    byte SIV = myGPS.getSIV();
+    Serial.print(F(" SIV: "));
+    Serial.print(SIV);
 
-        Serial.println();
-    } else {
-        Serial.print(".");
-        delay(50);
-    }
+    Serial.println();
+  } else {
+    Serial.print(".");
+    delay(50);
+  }
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -76,7 +76,9 @@ getPositionAccuracy	KEYWORD2
 
 getProtocolVersionHigh	KEYWORD2
 getProtocolVersionLow	KEYWORD2
-getProtocolVersion	KEYWORD2
+getProtocolVersion  KEYWORD2
+
+factoryReset    KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -79,6 +79,7 @@ getProtocolVersionLow	KEYWORD2
 getProtocolVersion  KEYWORD2
 
 factoryReset    KEYWORD2
+setAutoPVT  KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -470,7 +470,6 @@ void SFE_UBLOX_GPS::processUBXpacket(ubxPacket *msg)
         break;
 
     case UBX_CLASS_NAV:
-        Serial.println("**************************************************");
         if (msg->id == UBX_NAV_PVT && msg->len == 92)
         {
             //Parse various byte fields into global vars

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -442,7 +442,7 @@ void SFE_UBLOX_GPS::processUBX(uint8_t incoming, ubxPacket *incomingUBX)
 	{
 		//If a UBX_NAV_PVT packet comes in asynchronously, we need to fudge the startingSpot
 		uint16_t startingSpot = incomingUBX->startingSpot;
-		if (autoPVT && incomingUBX->cls == UBX_CLASS_NAV && incomingUBX->id == UBX_NAV_PVT)
+		if (incomingUBX->cls == UBX_CLASS_NAV && incomingUBX->id == UBX_NAV_PVT)
 			startingSpot = 20;
 		//Begin recording if counter goes past startingSpot
 		if( (incomingUBX->counter - 4) >= startingSpot)


### PR DESCRIPTION
This PR implements the suggestion in #3, which is to enable auto-reporting of navigation solutions and switching getPVT to report the data of the most recent one. Docs added to readme and Example13 shows the use.

NB: I'm testing on a Particle mesh device, so I have to do some minor cleanup to generate a PR, please test on a regular arduino (I don't own any, oops) before merging.