### PR TITLE
#5 only set I2C_BUFFER_LENGTH if not already defined

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -62,10 +62,9 @@
 //#elif __MK20DX256__
 //Teensy
 
-//#elif ARDUINO_ARCH_ESP32
-//ESP32 based platforms
+#endif
 
-#else
+#ifndef I2C_BUFFER_LENGTH
 
 //The catch-all default is 32
 #define I2C_BUFFER_LENGTH 32
@@ -369,3 +368,4 @@ class SFE_UBLOX_GPS
 };
 
 #endif
+


### PR DESCRIPTION
only set I2C_BUFFER_LENGTH if not already defined, this fixes compile warnings on ESP32:

```
Compiling .pioenvs/nodemcuv2/lib3cb/SparkFun Ublox Arduino Library_ID5746/SparkFun_Ublox_Arduino_Library.cpp.o
In file included from .piolibdeps/SparkFun Ublox Arduino Library_ID5746/src/SparkFun_Ublox_Arduino_Library.cpp:29:0:
.piolibdeps/SparkFun Ublox Arduino Library_ID5746/src/SparkFun_Ublox_Arduino_Library.h:71:0: warning: "I2C_BUFFER_LENGTH" redefined
#define I2C_BUFFER_LENGTH 32
^
In file included from .piolibdeps/SparkFun Ublox Arduino Library_ID5746/src/SparkFun_Ublox_Arduino_Library.h:38:0,
from .piolibdeps/SparkFun Ublox Arduino Library_ID5746/src/SparkFun_Ublox_Arduino_Library.cpp:29:
/home/trycoon/.platformio/packages/framework-arduinoespressif32/libraries/Wire/src/Wire.h:34:0: note: this is the location of the previous definition
#define I2C_BUFFER_LENGTH 128
```