### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -62,7 +62,7 @@ setUSBOutput	KEYWORD2
 setSPIOutput	KEYWORD2
 
 getVal8	KEYWORD2
-setVal  KEYWORD2
+setVal	KEYWORD2
 
 getSurveyMode	KEYWORD2
 setSurveyMode	KEYWORD2
@@ -77,22 +77,22 @@ getPositionAccuracy	KEYWORD2
 
 getProtocolVersionHigh	KEYWORD2
 getProtocolVersionLow	KEYWORD2
-getProtocolVersion  KEYWORD2
+getProtocolVersion	KEYWORD2
 
-getRELPOSNED    KEYWORD2
+getRELPOSNED	KEYWORD2
 
-enableDebugging KEYWORD2
-disableDebugging    KEYWORD2
+enableDebugging	KEYWORD2
+disableDebugging	KEYWORD2
 
-factoryReset    KEYWORD2
-setAutoPVT  KEYWORD2
+factoryReset	KEYWORD2
+setAutoPVT	KEYWORD2
 
-getYear KEYWORD2
-getMonth KEYWORD2
-getDay KEYWORD2
-getHour KEYWORD2
-getMinute KEYWORD2
-getSecond KEYWORD2
+getYear	KEYWORD2
+getMonth	KEYWORD2
+getDay	KEYWORD2
+getHour	KEYWORD2
+getMinute	KEYWORD2
+getSecond	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords