### PR TITLE
Updated VAL_LAYER definitions in SparkFun_Ublox_Arduino_Library.h (Issue #22)

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -148,9 +148,10 @@ const uint8_t VAL_SIZE_16 = 0x03; //Two bytes
 const uint8_t VAL_SIZE_32 = 0x04; //Four bytes
 const uint8_t VAL_SIZE_64 = 0x05; //Eight bytes
 
-const uint8_t VAL_LAYER_RAM = 0;
-const uint8_t VAL_LAYER_BBR = 1;
-const uint8_t VAL_LAYER_FLASH = 2;
+//These are the Bitfield layers definitions for the UBX-CFG-VALSET message (not to be confused with Bitfield deviceMask in UBX-CFG-CFG)
+const uint8_t VAL_LAYER_RAM = (1 << 0);
+const uint8_t VAL_LAYER_BBR = (1 << 1);
+const uint8_t VAL_LAYER_FLASH = (1 << 2);
 const uint8_t VAL_LAYER_DEFAULT = 7;
 
 //Below are various Groups, IDs, and sizes for various settings


### PR DESCRIPTION
This PR addresses Issue #22. It includes the updated Bitfield definitions for the _layers_ byte in the UBX-CFG-VALSET message.
Thanks!
Paul