### PR TITLE
Updated setVal, added 'multi' setVal and an Example (supersedes #28)

### DIFF
--- a/examples/ZED-F9P/Example10_multiSetVal/Example10_multiSetVal.ino
+++ b/examples/ZED-F9P/Example10_multiSetVal/Example10_multiSetVal.ino
@@ -1,0 +1,90 @@
+/*
+  Send UBX binary commands to enable RTCM sentences on Ublox ZED-F9P module
+  Based on Example7 By: Nathan Seidle
+  SparkFun Electronics
+  Updated by Paul Clark to demonstrate setVal8/16/32, newCfgValset8/16/32, addCfgValset8/16/32 and sendCfgValset8/16/32
+  Date: July 1st, 2019
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  Ublox changed how to configure their modules in 2019. As of version 23 of the UBX protocol the
+  UBX-CFG commands are deprecated; they still work, they just recommend using VALSET, VALGET, and VALDEL
+  commands instead. This example shows how to use this new command structure.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  ZED-F9P RTK2: https://www.sparkfun.com/products/15136
+  NEO-M8P RTK: https://www.sparkfun.com/products/15005
+  SAM-M8Q: https://www.sparkfun.com/products/15106
+
+  Hardware Connections:
+  Plug a Qwiic cable into the GPS and a RedBoard Qwiic or BlackBoard
+  If you don't have a platform with a Qwiic connection use the SparkFun Qwiic Breadboard Jumper (https://www.sparkfun.com/products/14425)
+  Open the serial monitor at 115200 baud to see the output
+*/
+
+#include <Wire.h> //Needed for I2C to GPS
+
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+SFE_UBLOX_GPS myGPS;
+
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); //Wait for user to open terminal
+  Serial.println("Ublox multi setVal example");
+
+  Wire.begin();
+  Wire.setClock(400000); //Increase I2C clock speed to 400kHz
+
+  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  myGPS.enableDebugging(); //Enable debug messages over Serial (default)
+  //myGPS.enableDebugging(SerialUSB); //Enable debug messages over Serial USB
+
+  bool setValueSuccess = true;
+
+  //These key values are hard coded. You can obtain them from the ZED-F9P interface description doc
+  //or from u-center's Messages->CFG->VALSET window. Keys must be 32-bit.
+  //Choose setVal8, setVal16 or setVal32 depending on the required value data width (1, 2 or 4 bytes)
+  //L, U1, I1, E1 and X1 values are 8-bit
+  //U2, I2, E2 and X2 values are 16-bit
+  //U4, I4, R4, E4, X4 values are 32-bit
+  
+  setValueSuccess &= myGPS.setVal8(0x10930006, 0); //Enable high precision NMEA (value is 8-bit (L / U1))
+  //setValueSuccess &= myGPS.setVal16(0x30210001, 100); //Set measurement rate to 100ms (10Hz update rate) (value is 16-bit (U2))
+  setValueSuccess &= myGPS.setVal16(0x30210001, 1000); //Set measurement rate to 1000ms (1Hz update rate) (value is 16-bit (U2))
+
+  //Below is the original way we enabled a single RTCM message on the I2C port. After that, we show how to do the same
+  //but with multiple messages all in one go using newCfgValset, addCfgValset and sendCfgValset.
+  //Original: myGPS.enableRTCMmessage(UBX_RTCM_1005, COM_PORT_I2C, 1); //Enable message 1005 to output through I2C port, message every second
+  
+  //Begin with newCfgValset8/16/32
+  setValueSuccess &= myGPS.newCfgValset8(0x209102bd, 1); //Set output rate of msg 1005 over the I2C port to once per measurement (value is 8-bit (U1))
+  //Add extra keyIDs and values using addCfgValset8/16/32
+  setValueSuccess &= myGPS.addCfgValset8(0x209102cc, 1); //Set output rate of msg 1077 over the I2C port to once per measurement (value is 8-bit (U1))
+  setValueSuccess &= myGPS.addCfgValset8(0x209102d1, 1); //Set output rate of msg 1087 over the I2C port to once per measurement (value is 8-bit (U1))
+  setValueSuccess &= myGPS.addCfgValset8(0x209102d6, 1); //Set output rate of msg 1127 over the I2C port to once per measurement (value is 8-bit (U1))
+  setValueSuccess &= myGPS.addCfgValset8(0x20910318, 1); //Set output rate of msg 1097 over the I2C port to once per measurement (value is 8-bit (U1))
+  // Add the final value and send the packet using sendCfgValset8/16/32
+  setValueSuccess &= myGPS.sendCfgValset8(0x20910303, 10); //Set output rate of msg 1230 over the I2C port to once every 10 measurements (value is 8-bit (U1))
+
+  if(setValueSuccess == true)
+  {
+    Serial.println("Values were successfully set");
+  }
+  else
+    Serial.println("Value set failed");
+    
+}
+
+void loop()
+{
+
+}

--- a/examples/ZED-F9P/Example10_multiSetVal/Example10_multiSetVal.ino
+++ b/examples/ZED-F9P/Example10_multiSetVal/Example10_multiSetVal.ino
@@ -28,8 +28,6 @@
 #include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
-
 void setup()
 {
   Serial.begin(115200);
@@ -56,17 +54,19 @@ void setup()
   //L, U1, I1, E1 and X1 values are 8-bit
   //U2, I2, E2 and X2 values are 16-bit
   //U4, I4, R4, E4, X4 values are 32-bit
-  
+
   setValueSuccess &= myGPS.setVal8(0x10930006, 0); //Enable high precision NMEA (value is 8-bit (L / U1))
-  //setValueSuccess &= myGPS.setVal16(0x30210001, 100); //Set measurement rate to 100ms (10Hz update rate) (value is 16-bit (U2))
+  //setValueSuccess &= myGPS.setVal16(0x30210001, 200); //Set measurement rate to 100ms (10Hz update rate) (value is 16-bit (U2))
+  //setValueSuccess &= myGPS.setVal16(0x30210001, 200, 1); //Set rate setting in RAM instead of BBR
   setValueSuccess &= myGPS.setVal16(0x30210001, 1000); //Set measurement rate to 1000ms (1Hz update rate) (value is 16-bit (U2))
 
   //Below is the original way we enabled a single RTCM message on the I2C port. After that, we show how to do the same
   //but with multiple messages all in one go using newCfgValset, addCfgValset and sendCfgValset.
   //Original: myGPS.enableRTCMmessage(UBX_RTCM_1005, COM_PORT_I2C, 1); //Enable message 1005 to output through I2C port, message every second
-  
+
   //Begin with newCfgValset8/16/32
   setValueSuccess &= myGPS.newCfgValset8(0x209102bd, 1); //Set output rate of msg 1005 over the I2C port to once per measurement (value is 8-bit (U1))
+  //setValueSuccess &= myGPS.newCfgValset8(0x209102bd, 1, 7); //Set this and the following settings into Flash/RAM/BBR instead of BBR
   //Add extra keyIDs and values using addCfgValset8/16/32
   setValueSuccess &= myGPS.addCfgValset8(0x209102cc, 1); //Set output rate of msg 1077 over the I2C port to once per measurement (value is 8-bit (U1))
   setValueSuccess &= myGPS.addCfgValset8(0x209102d1, 1); //Set output rate of msg 1087 over the I2C port to once per measurement (value is 8-bit (U1))
@@ -75,13 +75,12 @@ void setup()
   // Add the final value and send the packet using sendCfgValset8/16/32
   setValueSuccess &= myGPS.sendCfgValset8(0x20910303, 10); //Set output rate of msg 1230 over the I2C port to once every 10 measurements (value is 8-bit (U1))
 
-  if(setValueSuccess == true)
+  if (setValueSuccess == true)
   {
     Serial.println("Values were successfully set");
   }
   else
     Serial.println("Value set failed");
-    
 }
 
 void loop()

--- a/keywords.txt
+++ b/keywords.txt
@@ -63,6 +63,18 @@ setSPIOutput	KEYWORD2
 
 getVal8	KEYWORD2
 setVal	KEYWORD2
+setVal8	KEYWORD2
+setVal16	KEYWORD2
+setVal32	KEYWORD2
+newCfgValset8	KEYWORD2
+newCfgValset16	KEYWORD2
+newCfgValset32	KEYWORD2
+addCfgValset8	KEYWORD2
+addCfgValset16	KEYWORD2
+addCfgValset32	KEYWORD2
+sendCfgValset8	KEYWORD2
+sendCfgValset16	KEYWORD2
+sendCfgValset32	KEYWORD2
 
 getSurveyMode	KEYWORD2
 setSurveyMode	KEYWORD2

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -28,6 +28,11 @@
   - Modified ProcessUBXPacket to parse HPPOSLLH packet
   - Added query staleness verification for HPPOSLLH data 
 
+  Modified by Paul Clark, 1st July 2019
+  - Added 8 and 32 bit versions of setVal
+  - Added newCfgValset8/16/32, addCfgValset8/16/32 and sendCfgValset8/16/32
+    to support the setting of multiple keyID and value pairs simultaneously
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
@@ -951,40 +956,328 @@ uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
   return (extractByte(8));
 }
 
-//Given a key, set an 8-bit value
+//Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
 //Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
-  packetCfg.cls = UBX_CLASS_CFG;
-  packetCfg.id = UBX_CFG_VALSET;
-  packetCfg.len = 4 + 4 + 2; //4 byte header, 4 byte key ID, 2 bytes of value
-  packetCfg.startingSpot = 0;
+	return setVal16(key, value, layer, maxWait);
+}
 
-  //Clear packet payload
-  for (uint8_t x = 0; x < packetCfg.len; x++)
-    packetCfg.payload[x] = 0;
+//Given a key, set a 16-bit value
+//This function takes a full 32-bit key
+//Default layer is BBR
+//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
+{
+	packetCfg.cls = UBX_CLASS_CFG;
+	packetCfg.id = UBX_CFG_VALSET;
+	packetCfg.len = 4 + 4 + 2; //4 byte header, 4 byte key ID, 2 bytes of value
+	packetCfg.startingSpot = 0;
 
-  payloadCfg[0] = 0;     //Message Version - set to 0
-  payloadCfg[1] = layer; //By default we ask for the BBR layer
+	//Clear packet payload
+	for (uint16_t x = 0; x < packetCfg.len; x++)
+	packetCfg.payload[x] = 0;
 
-  //Load key into outgoing payload
-  payloadCfg[4] = key >> 8 * 0; //Key LSB
-  payloadCfg[5] = key >> 8 * 1;
-  payloadCfg[6] = key >> 8 * 2;
-  payloadCfg[7] = key >> 8 * 3;
+	payloadCfg[0] = 0;     //Message Version - set to 0
+	payloadCfg[1] = layer; //By default we ask for the BBR layer
 
-  //Load user's value
-  payloadCfg[8] = value >> 8 * 0; //Value LSB
-  payloadCfg[9] = value >> 8 * 1;
+	//Load key into outgoing payload
+	payloadCfg[4] = key >> 8 * 0; //Key LSB
+	payloadCfg[5] = key >> 8 * 1;
+	payloadCfg[6] = key >> 8 * 2;
+	payloadCfg[7] = key >> 8 * 3;
 
-  //Send VALSET command with this key and value
-  if (sendCommand(packetCfg, maxWait) == false)
-    return (false); //If command send fails then bail
+	//Load user's value
+	payloadCfg[8] = value >> 8 * 0; //Value LSB
+	payloadCfg[9] = value >> 8 * 1;
 
-  //All done
-  return (true);
+	//Send VALSET command with this key and value
+	if (sendCommand(packetCfg, maxWait) == false)
+	return (false); //If command send fails then bail
+
+	//All done
+	return (true);
+}
+
+//Given a key, set an 8-bit value
+//This function takes a full 32-bit key
+//Default layer is BBR
+//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint16_t maxWait)
+{
+	packetCfg.cls = UBX_CLASS_CFG;
+	packetCfg.id = UBX_CFG_VALSET;
+	packetCfg.len = 4 + 4 + 1; //4 byte header, 4 byte key ID, 1 byte value
+	packetCfg.startingSpot = 0;
+
+	//Clear packet payload
+	for (uint16_t x = 0; x < packetCfg.len; x++)
+	packetCfg.payload[x] = 0;
+
+	payloadCfg[0] = 0;     //Message Version - set to 0
+	payloadCfg[1] = layer; //By default we ask for the BBR layer
+
+	//Load key into outgoing payload
+	payloadCfg[4] = key >> 8 * 0; //Key LSB
+	payloadCfg[5] = key >> 8 * 1;
+	payloadCfg[6] = key >> 8 * 2;
+	payloadCfg[7] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[8] = value; //Value
+
+	//Send VALSET command with this key and value
+	if (sendCommand(packetCfg, maxWait) == false)
+	return (false); //If command send fails then bail
+
+	//All done
+	return (true);
+}
+
+//Given a key, set a 32-bit value
+//This function takes a full 32-bit key
+//Default layer is BBR
+//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+uint8_t SFE_UBLOX_GPS::setVal32(uint32_t key, uint32_t value, uint8_t layer, uint16_t maxWait)
+{
+	packetCfg.cls = UBX_CLASS_CFG;
+	packetCfg.id = UBX_CFG_VALSET;
+	packetCfg.len = 4 + 4 + 4; //4 byte header, 4 byte key ID, 4 bytes of value
+	packetCfg.startingSpot = 0;
+
+	//Clear packet payload
+	for (uint16_t x = 0; x < packetCfg.len; x++)
+	packetCfg.payload[x] = 0;
+
+	payloadCfg[0] = 0;     //Message Version - set to 0
+	payloadCfg[1] = layer; //By default we ask for the BBR layer
+
+	//Load key into outgoing payload
+	payloadCfg[4] = key >> 8 * 0; //Key LSB
+	payloadCfg[5] = key >> 8 * 1;
+	payloadCfg[6] = key >> 8 * 2;
+	payloadCfg[7] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[8] = value >> 8 * 0; //Value LSB
+	payloadCfg[9] = value >> 8 * 1;
+	payloadCfg[10] = value >> 8 * 2;
+	payloadCfg[11] = value >> 8 * 3;
+
+	//Send VALSET command with this key and value
+	if (sendCommand(packetCfg, maxWait) == false)
+	return (false); //If command send fails then bail
+
+	//All done
+	return (true);
+}
+
+//Start defining a new UBX-CFG-VALSET ubxPacket
+//This function takes a full 32-bit key and 32-bit value
+//Default layer is BBR
+//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+uint8_t SFE_UBLOX_GPS::newCfgValset32(uint32_t key, uint32_t value, uint8_t layer)
+{
+	packetCfg.cls = UBX_CLASS_CFG;
+	packetCfg.id = UBX_CFG_VALSET;
+	packetCfg.len = 4 + 4 + 4; //4 byte header, 4 byte key ID, 4 bytes of value
+	packetCfg.startingSpot = 0;
+
+	//Clear packet payload
+	for (uint16_t x = 0; x < MAX_PAYLOAD_SIZE; x++)
+	packetCfg.payload[x] = 0;
+
+	payloadCfg[0] = 0;     //Message Version - set to 0
+	payloadCfg[1] = layer; //By default we ask for the BBR layer
+
+	//Load key into outgoing payload
+	payloadCfg[4] = key >> 8 * 0; //Key LSB
+	payloadCfg[5] = key >> 8 * 1;
+	payloadCfg[6] = key >> 8 * 2;
+	payloadCfg[7] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[8] = value >> 8 * 0; //Value LSB
+	payloadCfg[9] = value >> 8 * 1;
+	payloadCfg[10] = value >> 8 * 2;
+	payloadCfg[11] = value >> 8 * 3;
+
+	//All done
+	return (true);
+}
+
+//Start defining a new UBX-CFG-VALSET ubxPacket
+//This function takes a full 32-bit key and 16-bit value
+//Default layer is BBR
+//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+uint8_t SFE_UBLOX_GPS::newCfgValset16(uint32_t key, uint16_t value, uint8_t layer)
+{
+	packetCfg.cls = UBX_CLASS_CFG;
+	packetCfg.id = UBX_CFG_VALSET;
+	packetCfg.len = 4 + 4 + 2; //4 byte header, 4 byte key ID, 2 bytes of value
+	packetCfg.startingSpot = 0;
+
+	//Clear packet payload
+	for (uint16_t x = 0; x < MAX_PAYLOAD_SIZE; x++)
+	packetCfg.payload[x] = 0;
+
+	payloadCfg[0] = 0;     //Message Version - set to 0
+	payloadCfg[1] = layer; //By default we ask for the BBR layer
+
+	//Load key into outgoing payload
+	payloadCfg[4] = key >> 8 * 0; //Key LSB
+	payloadCfg[5] = key >> 8 * 1;
+	payloadCfg[6] = key >> 8 * 2;
+	payloadCfg[7] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[8] = value >> 8 * 0; //Value LSB
+	payloadCfg[9] = value >> 8 * 1;
+
+	//All done
+	return (true);
+}
+
+//Start defining a new UBX-CFG-VALSET ubxPacket
+//This function takes a full 32-bit key and 8-bit value
+//Default layer is BBR
+//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+uint8_t SFE_UBLOX_GPS::newCfgValset8(uint32_t key, uint8_t value, uint8_t layer)
+{
+	packetCfg.cls = UBX_CLASS_CFG;
+	packetCfg.id = UBX_CFG_VALSET;
+	packetCfg.len = 4 + 4 + 1; //4 byte header, 4 byte key ID, 1 byte value
+	packetCfg.startingSpot = 0;
+
+	//Clear packet payload
+	for (uint16_t x = 0; x < MAX_PAYLOAD_SIZE; x++)
+	packetCfg.payload[x] = 0;
+
+	payloadCfg[0] = 0;     //Message Version - set to 0
+	payloadCfg[1] = layer; //By default we ask for the BBR layer
+
+	//Load key into outgoing payload
+	payloadCfg[4] = key >> 8 * 0; //Key LSB
+	payloadCfg[5] = key >> 8 * 1;
+	payloadCfg[6] = key >> 8 * 2;
+	payloadCfg[7] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[8] = value; //Value
+
+	//All done
+	return (true);
+}
+
+//Add another keyID and value to an existing UBX-CFG-VALSET ubxPacket
+//This function takes a full 32-bit key and 32-bit value
+uint8_t SFE_UBLOX_GPS::addCfgValset32(uint32_t key, uint32_t value)
+{
+	//Load key into outgoing payload
+	payloadCfg[packetCfg.len + 0] = key >> 8 * 0; //Key LSB
+	payloadCfg[packetCfg.len + 1] = key >> 8 * 1;
+	payloadCfg[packetCfg.len + 2] = key >> 8 * 2;
+	payloadCfg[packetCfg.len + 3] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[packetCfg.len + 4] = value >> 8 * 0; //Value LSB
+	payloadCfg[packetCfg.len + 5] = value >> 8 * 1;
+	payloadCfg[packetCfg.len + 6] = value >> 8 * 2;
+	payloadCfg[packetCfg.len + 7] = value >> 8 * 3;
+
+	//Update packet length: 4 byte key ID, 4 bytes of value
+	packetCfg.len = packetCfg.len + 4 + 4;
+
+	//All done
+	return (true);
+}
+
+//Add another keyID and value to an existing UBX-CFG-VALSET ubxPacket
+//This function takes a full 32-bit key and 16-bit value
+uint8_t SFE_UBLOX_GPS::addCfgValset16(uint32_t key, uint16_t value)
+{
+	//Load key into outgoing payload
+	payloadCfg[packetCfg.len + 0] = key >> 8 * 0; //Key LSB
+	payloadCfg[packetCfg.len + 1] = key >> 8 * 1;
+	payloadCfg[packetCfg.len + 2] = key >> 8 * 2;
+	payloadCfg[packetCfg.len + 3] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[packetCfg.len + 4] = value >> 8 * 0; //Value LSB
+	payloadCfg[packetCfg.len + 5] = value >> 8 * 1;
+
+	//Update packet length: 4 byte key ID, 2 bytes of value
+	packetCfg.len = packetCfg.len + 4 + 2;
+
+	//All done
+	return (true);
+}
+
+//Add another keyID and value to an existing UBX-CFG-VALSET ubxPacket
+//This function takes a full 32-bit key and 8-bit value
+uint8_t SFE_UBLOX_GPS::addCfgValset8(uint32_t key, uint8_t value)
+{
+	//Load key into outgoing payload
+	payloadCfg[packetCfg.len + 0] = key >> 8 * 0; //Key LSB
+	payloadCfg[packetCfg.len + 1] = key >> 8 * 1;
+	payloadCfg[packetCfg.len + 2] = key >> 8 * 2;
+	payloadCfg[packetCfg.len + 3] = key >> 8 * 3;
+
+	//Load user's value
+	payloadCfg[packetCfg.len + 4] = value; //Value
+
+	//Update packet length: 4 byte key ID, 1 byte value
+	packetCfg.len = packetCfg.len + 4 + 1;
+
+	//All done
+	return (true);
+}
+
+//Add a final keyID and value to an existing UBX-CFG-VALSET ubxPacket and send it
+//This function takes a full 32-bit key and 32-bit value
+uint8_t SFE_UBLOX_GPS::sendCfgValset32(uint32_t key, uint32_t value, uint16_t maxWait)
+{
+	//Load keyID and value into outgoing payload
+	addCfgValset32(key, value);
+	
+	//Send VALSET command with this key and value
+	if (sendCommand(packetCfg, maxWait) == false)
+	return (false); //If command send fails then bail
+
+	//All done
+	return (true);
+}
+
+//Add a final keyID and value to an existing UBX-CFG-VALSET ubxPacket and send it
+//This function takes a full 32-bit key and 16-bit value
+uint8_t SFE_UBLOX_GPS::sendCfgValset16(uint32_t key, uint16_t value, uint16_t maxWait)
+{
+	//Load keyID and value into outgoing payload
+	addCfgValset16(key, value);
+	
+	//Send VALSET command with this key and value
+	if (sendCommand(packetCfg, maxWait) == false)
+	return (false); //If command send fails then bail
+
+	//All done
+	return (true);
+}
+
+//Add a final keyID and value to an existing UBX-CFG-VALSET ubxPacket and send it
+//This function takes a full 32-bit key and 8-bit value
+uint8_t SFE_UBLOX_GPS::sendCfgValset8(uint32_t key, uint8_t value, uint16_t maxWait)
+{
+	//Load keyID and value into outgoing payload
+	addCfgValset8(key, value);
+	
+	//Send VALSET command with this key and value
+	if (sendCommand(packetCfg, maxWait) == false)
+	return (false); //If command send fails then bail
+
+	//All done
+	return (true);
 }
 
 //Get the current TimeMode3 settings - these contain survey in statuses

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -174,7 +174,8 @@ const uint8_t VAL_ID_I2C_ADDRESS = 0x01;
 
 #ifndef MAX_PAYLOAD_SIZE
 
-#define MAX_PAYLOAD_SIZE 768 //Worst case: UBX_CFG_VALSET packet with 64 keyIDs each with 64 bit values
+#define MAX_PAYLOAD_SIZE 128
+//#define MAX_PAYLOAD_SIZE 768 //Worst case: UBX_CFG_VALSET packet with 64 keyIDs each with 64 bit values
 
 #endif
 

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -28,7 +28,12 @@
   - Modified ProcessUBXPacket to parse HPPOSLLH packet
   - Added query staleness verification for HPPOSLLH data 
 
-  This program is distributed in the hope that it will be useful,
+   Modified by Paul Clark, 1st July 2019
+   - Added 8 and 32 bit versions of setVal
+   - Added newCfgValset8/16/32, addCfgValset8/16/32 and sendCfgValset8/16/32
+     to support the setting of multiple keyID and value pairs simultaneously
+
+ This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
   GNU General Public License for more details.
@@ -152,7 +157,6 @@ const uint8_t VAL_SIZE_64 = 0x05; //Eight bytes
 const uint8_t VAL_LAYER_RAM = (1 << 0);
 const uint8_t VAL_LAYER_BBR = (1 << 1);
 const uint8_t VAL_LAYER_FLASH = (1 << 2);
-const uint8_t VAL_LAYER_DEFAULT = 7;
 
 //Below are various Groups, IDs, and sizes for various settings
 //These can be used to call getVal/setVal/delVal
@@ -170,7 +174,7 @@ const uint8_t VAL_ID_I2C_ADDRESS = 0x01;
 
 #ifndef MAX_PAYLOAD_SIZE
 
-#define MAX_PAYLOAD_SIZE 64 //Some commands are larger than 64 bytes but this covers most
+#define MAX_PAYLOAD_SIZE 768 //Worst case: UBX_CFG_VALSET packet with 64 keyIDs each with 64 bit values
 
 #endif
 
@@ -277,7 +281,19 @@ public:
 	//General configuration (used only on protocol v27 and higher - ie, ZED-F9P)
 	uint8_t getVal8(uint16_t group, uint16_t id, uint8_t size, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250); //Returns the value at a given group/id/size location
 	uint8_t getVal8(uint32_t keyID, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250);							   //Returns the value at a given group/id/size location
-	uint8_t setVal(uint32_t keyID, uint16_t value, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250);			   //Returns the value at a given group/id/size location
+	uint8_t setVal(uint32_t keyID, uint16_t value, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250);		//Sets the 16-bit value at a given group/id/size location
+	uint8_t setVal8(uint32_t keyID, uint8_t value, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250);		//Sets the 8-bit value at a given group/id/size location
+	uint8_t setVal16(uint32_t keyID, uint16_t value, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250);	//Sets the 16-bit value at a given group/id/size location
+	uint8_t setVal32(uint32_t keyID, uint32_t value, uint8_t layer = VAL_LAYER_BBR, uint16_t maxWait = 250);	//Sets the 32-bit value at a given group/id/size location
+	uint8_t newCfgValset8(uint32_t keyID, uint8_t value, uint8_t layer = VAL_LAYER_BBR);    //Define a new UBX-CFG-VALSET with the given KeyID and 8-bit value
+	uint8_t newCfgValset16(uint32_t keyID, uint16_t value, uint8_t layer = VAL_LAYER_BBR);  //Define a new UBX-CFG-VALSET with the given KeyID and 16-bit value
+	uint8_t newCfgValset32(uint32_t keyID, uint32_t value, uint8_t layer = VAL_LAYER_BBR);  //Define a new UBX-CFG-VALSET with the given KeyID and 32-bit value
+	uint8_t addCfgValset8(uint32_t keyID, uint8_t value);      //Add a new KeyID and 8-bit value to an existing UBX-CFG-VALSET ubxPacket
+	uint8_t addCfgValset16(uint32_t keyID, uint16_t value);    //Add a new KeyID and 16-bit value to an existing UBX-CFG-VALSET ubxPacket
+	uint8_t addCfgValset32(uint32_t keyID, uint32_t value);    //Add a new KeyID and 32-bit value to an existing UBX-CFG-VALSET ubxPacket
+	uint8_t sendCfgValset8(uint32_t keyID, uint8_t value, uint16_t maxWait = 250);     //Add the final KeyID and 8-bit value to an existing UBX-CFG-VALSET ubxPacket and send it
+	uint8_t sendCfgValset16(uint32_t keyID, uint16_t value, uint16_t maxWait = 250);   //Add the final KeyID and 16-bit value to an existing UBX-CFG-VALSET ubxPacket and send it
+	uint8_t sendCfgValset32(uint32_t keyID, uint32_t value, uint16_t maxWait = 250);   //Add the final KeyID and 32-bit value to an existing UBX-CFG-VALSET ubxPacket and send it
 
 	//Functions used for RTK and base station setup
 	boolean getSurveyMode(uint16_t maxWait = 250);																   //Get the current TimeMode3 settings


### PR DESCRIPTION
Added 8- and 32-bit versions of setVal. See Issue #21 for details.
Added 8-, 16- and 32-bit versions of newCfgValset, addCfgValset and sendCfgValset to provide multiSetVal support. See Issue #20 and #23 for details.
Included an example showing how to use the new functions.
This PR supersedes #28.