### PR TITLE
move partial changelog to 'thanks' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Thanks to:
 * [tve](https://github.com/tve) for building out serial additions and examples
 * [Redstoned](https://github.com/Redstoned) and [davidallenmann](https://github.com/davidallenmann) for adding PVT date and time
 * [wittend](https://forum.sparkfun.com/viewtopic.php?t=49874) for pointing out the RTCM print bug
-* Big thanks to [PaulZC] for implementing the combined key ValSet method
+* Big thanks to [PaulZC](https://github.com/PaulZC) for implementing the combined key ValSet method
+* [RollieRowland](https://github.com/RollieRowland) for adding HPPOSLLH (High Precision Geodetic Position)
 
 Need a library for the Ublox and Particle? Checkout the [Particle library](https://github.com/aseelye/SparkFun_Ublox_Particle_Library) fork.
 
@@ -103,7 +104,3 @@ Distributed as-is; no warranty is given.
 
 - Your friends at SparkFun.
 
-Thanks to:
-* David Mann @ Loggerhead Instruments, April 2019, date and time additions
-* Steven Rowland, June  2019, HPPOSLLH (High Precision Geodetic Position)
-* Paul Clark, July 2019, 8/16/32 bit versions of setVal, addCfg, etc

--- a/README.md
+++ b/README.md
@@ -102,3 +102,8 @@ Please use, reuse, and modify these files as you see fit. Please maintain attrib
 Distributed as-is; no warranty is given.
 
 - Your friends at SparkFun.
+
+Thanks to:
+* David Mann @ Loggerhead Instruments, April 2019, date and time additions
+* Steven Rowland, June  2019, HPPOSLLH (High Precision Geodetic Position)
+* Paul Clark, July 2019, 8/16/32 bit versions of setVal, addCfg, etc

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -17,22 +17,6 @@
 	Development environment specifics:
 	Arduino IDE 1.8.5
 
-	Modified by David Mann @ Loggerhead Instruments, 16 April 2019
-	- Added support for parsing date and time
-	- Added functions getYear(), getMonth(), getDay(), getHour(), getMinute(), getSecond()
-
-	Modified by Steven Rowland, June 11th, 2019
-	- Added functionality for reading HPPOSLLH (High Precision Geodetic Position)
-	- Added getTimeOfWeek(), getHighResLatitude(). getHighResLongitude(), getElipsoid(), 
-	getMeanSeaLevel(), getHorizontalAccuracy(), getVerticalAccuracy(), getHPPOSLLH()
-	- Modified ProcessUBXPacket to parse HPPOSLLH packet
-	- Added query staleness verification for HPPOSLLH data 
-
-	Modified by Paul Clark, 1st July 2019
-	- Added 8 and 32 bit versions of setVal
-	- Added newCfgValset8/16/32, addCfgValset8/16/32 and sendCfgValset8/16/32
-	to support the setting of multiple keyID and value pairs simultaneously
-
 	SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
 	The MIT License (MIT)
 	Copyright (c) 2016 SparkFun Electronics

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -17,21 +17,6 @@
 	Development environment specifics:
 	Arduino IDE 1.8.5
 
-	Modified by David Mann @ Loggerhead Instruments, 16 April 2019
-	- Added support for parsing date and time
-	- Added functions getYear(), getMonth(), getDay(), getHour(), getMinute(), getSecond()
-
-	Modified by Steven Rowland, June 11th, 2019
-	- Added functionality for reading HPPOSLLH (High Precision Geodetic Position)
-	- Added getTimeOfWeek(), getHighResLatitude(). getHighResLongitude(), getElipsoid(), 
-	getMeanSeaLevel(), getHorizontalAccuracy(), getVerticalAccuracy(), getHPPOSLLH()
-	- Modified ProcessUBXPacket to parse HPPOSLLH packet
-	- Added query staleness verification for HPPOSLLH data 
-
-	Modified by Paul Clark, 1st July 2019
-	- Added 8 and 32 bit versions of setVal
-	- Added newCfgValset8/16/32, addCfgValset8/16/32 and sendCfgValset8/16/32
-		to support the setting of multiple keyID and value pairs simultaneously
 
 	SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
 	The MIT License (MIT)


### PR DESCRIPTION
Not sure what the sparkfun standard is, but the partial changelog in the code was weird and duplicative. It looks like the releases is the canonical changelog, so I converted it to a 'thanks' at the bottom of the README. YMMV.