### PR TITLE
Added setDynamicModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Thanks to:
 * [tve](https://github.com/tve) for building out serial additions and examples
 * [Redstoned](https://github.com/Redstoned) and [davidallenmann](https://github.com/davidallenmann) for adding PVT date and time
 * [wittend](https://forum.sparkfun.com/viewtopic.php?t=49874) for pointing out the RTCM print bug
-* Big thanks to [PaulZC](https://github.com/PaulZC) for implementing the combined key ValSet method
+* Big thanks to [PaulZC](https://github.com/PaulZC) for implementing the combined key ValSet method and geofence functions
 * [RollieRowland](https://github.com/RollieRowland) for adding HPPOSLLH (High Precision Geodetic Position)
 * [tedder](https://github.com/tedder) for moving iTOW to PVT instead of HPPOS and comment cleanup
 

--- a/examples/Example18_Geofence/Example18_Geofence.ino
+++ b/examples/Example18_Geofence/Example18_Geofence.ino
@@ -1,0 +1,168 @@
+/*
+  u-blox M8 geofence example
+
+  Written by Paul Clark (PaulZC)
+  10th December 2019
+
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  This example demonstrates how to use the addGeofence and getGeofenceState functions
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  ZED-F9P RTK2: https://www.sparkfun.com/products/15136
+  NEO-M8P RTK: https://www.sparkfun.com/products/15005
+  SAM-M8Q: https://www.sparkfun.com/products/15210
+  ZOE-M8Q: https://www.sparkfun.com/products/15193
+
+  This example powers up the GPS and reads the fix.
+  Once a valid 3D fix has been found, the code reads the latitude and longitude.
+  The code then sets four geofences around that position with a radii of 5m, 10m, 15m and 20m with 95% confidence.
+  The code then monitors the geofence status.
+  The LED will be illuminated if you are inside the _combined_ geofence (i.e. within the 20m radius).
+
+  This code has been tested on the ZOE-M8Q.
+*/
+
+#define LED LED_BUILTIN // Change this if your LED is on a different pin
+
+#include <Wire.h> // Needed for I2C
+
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+SFE_UBLOX_GPS myGPS;
+
+void setup()
+{
+  pinMode(LED, OUTPUT);
+
+  // Set up the I2C pins
+  Wire.begin();
+
+  // Start the console serial port
+  Serial.begin(115200);
+  while (!Serial); // Wait for the user to open the serial monitor
+  delay(100);
+  Serial.println();
+  Serial.println();
+  Serial.println(F("u-blox M8 geofence example"));
+  Serial.println();
+  Serial.println();
+
+  delay(1000); // Let the GPS power up
+  
+  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  //myGPS.enableDebugging(); // Enable debug messages
+  myGPS.setI2COutput(COM_TYPE_UBX); // Limit I2C output to UBX (disable the NMEA noise)
+
+  Serial.println(F("Waiting for a 3D fix..."));
+
+  byte fixType = 0;
+
+  while (fixType != 3)
+  {
+    fixType = myGPS.getFixType(); // Get the fix type
+    Serial.print(F("Fix: ")); // Print it
+    Serial.print(fixType);
+    if(fixType == 0) Serial.print(F(" = No fix"));
+    else if(fixType == 1) Serial.print(F(" = Dead reckoning"));
+    else if(fixType == 2) Serial.print(F(" = 2D"));
+    else if(fixType == 3) Serial.print(F(" = 3D"));
+    else if(fixType == 4) Serial.print(F(" = GNSS + Dead reckoning"));
+    Serial.println();
+    delay(1000);
+  }
+
+  Serial.println(F("3D fix found!"));
+
+  long latitude = myGPS.getLatitude(); // Get the latitude in degrees * 10^-7
+  Serial.print(F("Lat: "));
+  Serial.print(latitude);
+
+  long longitude = myGPS.getLongitude(); // Get the longitude in degrees * 10^-7
+  Serial.print(F("   Long: "));
+  Serial.println(longitude);
+
+  uint32_t radius = 500; // Set the radius to 5m (radius is in m * 10^-2 i.e. cm)
+  
+  byte confidence = 2; // Set the confidence level: 0=none, 1=68%, 2=95%, 3=99.7%, 4=99.99%
+
+  // Call clearGeofences() to clear all existing geofences.
+  Serial.print(F("Clearing any existing geofences. clearGeofences returned: "));
+  Serial.println(myGPS.clearGeofences());
+
+  // It is possible to define up to four geofences.
+  // Call addGeofence up to four times to define them.
+  Serial.println(F("Setting the geofences:"));
+  
+  Serial.print(F("addGeofence for geofence 1 returned: "));
+  Serial.println(myGPS.addGeofence(latitude, longitude, radius, confidence));
+  
+  radius = 1000; // 10m
+  Serial.print(F("addGeofence for geofence 2 returned: "));
+  Serial.println(myGPS.addGeofence(latitude, longitude, radius, confidence));
+  
+  radius = 1500; // 15m
+  Serial.print(F("addGeofence for geofence 3 returned: "));
+  Serial.println(myGPS.addGeofence(latitude, longitude, radius, confidence));
+  
+  radius = 2000; // 20m
+  Serial.print(F("addGeofence for geofence 4 returned: "));
+  Serial.println(myGPS.addGeofence(latitude, longitude, radius, confidence));
+}
+
+void loop()
+{
+  geofenceState currentGeofenceState; // Create storage for the geofence state
+
+  boolean result = myGPS.getGeofenceState(currentGeofenceState);
+
+  Serial.print(F("getGeofenceState returned: ")); // Print the combined state
+  Serial.print(result); // Get the geofence state
+
+  if (!result) // If getGeofenceState did not return true
+  {
+    Serial.println(F(".")); // Tidy up
+    return; // and go round the loop again
+  }
+  
+  Serial.print(F(". status is: ")); // Print the status
+  Serial.print(currentGeofenceState.status);
+  
+  Serial.print(F(". numFences is: ")); // Print the numFences
+  Serial.print(currentGeofenceState.numFences);
+  
+  Serial.print(F(". combState is: ")); // Print the combined state
+  Serial.print(currentGeofenceState.combState);
+  
+  if (currentGeofenceState.combState == 0)
+  {
+    Serial.print(F(" = Unknown"));
+    digitalWrite(LED, LOW);
+  }
+  if (currentGeofenceState.combState == 1)
+  {
+    Serial.print(F(" = Inside"));
+    digitalWrite(LED, HIGH);
+  }
+  else if (currentGeofenceState.combState == 2)
+  {
+    Serial.print(F(" = Outside"));
+    digitalWrite(LED, LOW);
+  }
+
+  Serial.print(F(". The individual states are: ")); // Print the state of each geofence
+  for(int i = 0; i < currentGeofenceState.numFences; i++)
+  {
+    if (i > 0) Serial.print(F(","));
+    Serial.print(currentGeofenceState.states[i]);
+  }
+  Serial.println();
+  
+  delay(1000);
+}

--- a/examples/Example19_DynamicModel/Example19_DynamicModel.ino
+++ b/examples/Example19_DynamicModel/Example19_DynamicModel.ino
@@ -1,0 +1,102 @@
+/*
+  Set Dynamic Model
+  By: Paul Clark (PaulZC)
+  Date: December 18th, 2019
+  
+  Based extensively on Example3_GetPosition
+  By: Nathan Seidle
+  SparkFun Electronics
+  Date: January 3rd, 2019
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  This example shows how to change the Ublox module's dynamic platform model and then
+  query its lat/long/altitude. We also turn off the NMEA output on the I2C port.
+  This decreases the amount of I2C traffic dramatically.
+
+  Possible values for the dynamic model are: PORTABLE, STATIONARY, PEDESTRIAN, AUTOMOTIVE,
+  SEA, AIRBORNE1g, AIRBORNE2g, AIRBORNE4g, WRIST, BIKE
+
+  Note: Long/lat are large numbers because they are * 10^7. To convert lat/long
+  to something google maps understands simply divide the numbers by 10,000,000. We 
+  do this so that we don't have to use floating point numbers.
+
+  Leave NMEA parsing behind. Now you can simply ask the module for the datums you want!
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  ZED-F9P RTK2: https://www.sparkfun.com/products/15136
+  NEO-M8P RTK: https://www.sparkfun.com/products/15005
+  SAM-M8Q: https://www.sparkfun.com/products/15106
+
+  Hardware Connections:
+  Plug a Qwiic cable into the GPS and a BlackBoard
+  If you don't have a platform with a Qwiic connection use the SparkFun Qwiic Breadboard Jumper (https://www.sparkfun.com/products/14425)
+  Open the serial monitor at 115200 baud to see the output
+*/
+
+#include <Wire.h> //Needed for I2C to GPS
+
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+SFE_UBLOX_GPS myGPS;
+
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); //Wait for user to open terminal
+  Serial.println("SparkFun Ublox Example");
+
+  Wire.begin();
+
+  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  //myGPS.enableDebugging(); // Uncomment this line to enable debug messages
+
+  // If we are going to change the dynamic platform model, let's do it here.
+  // Possible values are:
+  // PORTABLE, STATIONARY, PEDESTRIAN, AUTOMOTIVE, SEA, AIRBORNE1g, AIRBORNE2g, AIRBORNE4g, WRIST, BIKE
+  
+  if (!myGPS.setDynamicModel(myGPS.PORTABLE)) // Set the dynamic model to PORTABLE
+  {
+    Serial.println("***!!! Warning: setDynamicModel failed !!!***");
+  }
+  else
+  {
+    Serial.println("Dynamic platform model changed successfully!");
+  }
+          
+  myGPS.setI2COutput(COM_TYPE_UBX); //Set the I2C port to output UBX only (turn off NMEA noise)
+  //myGPS.saveConfiguration(); //Uncomment this line to save the current settings to flash and BBR
+}
+
+void loop()
+{
+  //Query module only every second. Doing it more often will just cause I2C traffic.
+  //The module only responds when a new position is available
+  if (millis() - lastTime > 1000)
+  {
+    lastTime = millis(); //Update the timer
+    
+    long latitude = myGPS.getLatitude();
+    Serial.print(F("Lat: "));
+    Serial.print(latitude);
+
+    long longitude = myGPS.getLongitude();
+    Serial.print(F(" Long: "));
+    Serial.print(longitude);
+    Serial.print(F(" (degrees * 10^-7)"));
+
+    long altitude = myGPS.getAltitude();
+    Serial.print(F(" Alt: "));
+    Serial.print(altitude);
+    Serial.print(F(" (mm)"));
+
+    Serial.println();
+  }
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -121,6 +121,10 @@ getGeoidSeparation KEYWORD2
 getHorizontalAccuracy KEYWORD2
 getVerticalAccuracy KEYWORD2
 
+addGeofence	KEYWORD2
+clearGeofences	KEYWORD2
+getGeofenceState	KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/keywords.txt
+++ b/keywords.txt
@@ -125,6 +125,8 @@ addGeofence	KEYWORD2
 clearGeofences	KEYWORD2
 getGeofenceState	KEYWORD2
 
+setDynamicModel	KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -1789,6 +1789,33 @@ boolean SFE_UBLOX_GPS::getGeofenceState(geofenceState &currentGeofenceState, uin
   return(true);
 }
 
+//Changes the dynamic platform model using UBX-CFG-NAV5
+//Possible values are:
+//PORTABLE,STATIONARY,PEDESTRIAN,AUTOMOTIVE,SEA,
+//AIRBORNE1g,AIRBORNE2g,AIRBORNE4g,WRIST,BIKE
+//WRIST is not supported in protocol versions less than 18
+//BIKE is supported in protocol versions 19.2
+
+boolean SFE_UBLOX_GPS::setDynamicModel(uint8_t newDynamicModel, uint16_t maxWait)
+{
+  packetCfg.cls = UBX_CLASS_CFG;
+  packetCfg.id = UBX_CFG_NAV5;
+  packetCfg.len = 0;
+  packetCfg.startingSpot = 0;
+
+  if (sendCommand(packetCfg, maxWait) == false) //Ask module for the current navigation model settings. Loads into payloadCfg.
+  return (false);
+
+  payloadCfg[0] = 0x01; // mask: set only the dyn bit (0)
+  payloadCfg[1] = 0x00; // mask
+  payloadCfg[2] = newDynamicModel; // dynModel
+
+  packetCfg.len = 36;
+  packetCfg.startingSpot = 0;
+
+  return (sendCommand(packetCfg, maxWait)); //Wait for ack
+}
+
 //Given a spot in the payload array, extract four bytes and build a long
 uint32_t SFE_UBLOX_GPS::extractLong(uint8_t spotToStart)
 {

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -425,7 +425,8 @@ public:
   enum dynModel // Possible values for the dynamic platform model
   {
     PORTABLE = 0,
-    STATIONARY,
+    // 1 is not defined
+    STATIONARY = 2,
     PEDESTRIAN,
     AUTOMOTIVE,
     SEA,

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -107,6 +107,8 @@ const uint8_t UBX_CFG_GEOFENCE = 0x69; //Used to configure a geofence
 const uint8_t UBX_CFG_ANT = 0x13; //Used to configure the antenna control settings
 const uint8_t UBX_NAV_GEOFENCE = 0x39; //Used to poll the geofence status
 
+const uint8_t UBX_CFG_NAV5 = 0x24; //Used to configure the navigation engine including the dynamic model
+
 const uint8_t UBX_CFG_TMODE3 = 0x71; //Used to enable Survey In Mode
 const uint8_t SVIN_MODE_DISABLE = 0x00;
 const uint8_t SVIN_MODE_ENABLE = 0x01;
@@ -344,6 +346,9 @@ public:
   boolean clearGeofences(uint16_t maxWait = 2000); //Clears all geofences
   boolean getGeofenceState(geofenceState &currentGeofenceState, uint16_t maxWait = 2000);  //Returns the combined geofence state
 
+  //Change the dynamic platform model using UBX-CFG-NAV5
+  boolean setDynamicModel(uint8_t newDynamicModel = PEDESTRIAN, uint16_t maxWait = 2000);
+
 	//Survey-in specific controls
 	struct svinStructure
 	{
@@ -416,6 +421,20 @@ public:
 	uint32_t verticalAccuracy;
 
 	uint16_t rtcmFrameCounter = 0; //Tracks the type of incoming byte inside RTCM frame
+
+  enum dynModel // Possible values for the dynamic platform model
+  {
+    PORTABLE = 0,
+    STATIONARY,
+    PEDESTRIAN,
+    AUTOMOTIVE,
+    SEA,
+    AIRBORNE1g,
+    AIRBORNE2g,
+    AIRBORNE4g,
+    WRIST, // Not supported in protocol versions less than 18
+    BIKE // Supported in protocol versions 19.2
+  };
 
 private:
 	//Depending on the sentence type the processor will load characters into different arrays


### PR DESCRIPTION
Hi Nathan (@nseidle),
Here's a PR which adds a new function: setDynamicModel.
(Apologies. This PR also seems to include the changes for PR #50. Clearly I don't yet know how to use branches correctly!)
setDynamicModel uses the UBX-CFG-NAV5 message to set the navigation model settings (dynamic platform model) to: PORTABLE, STATIONARY, PEDESTRIAN, AUTOMOTIVE, SEA, AIRBORNE1g, AIRBORNE2g, AIRBORNE4g, WRIST, or BIKE.
This is essential for M8 receivers launched on high altitude balloons - you'll get very strange position fixes if you don't change the model to AIRBORNE1g.
I've included an example and have tested it on the Qwiic ZOE-M8Q breakout.
Enjoy!
Paul