### PR TITLE
Long UBX packet may be lost as checksum failed.

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -451,7 +451,7 @@ private:
 	boolean autoPVT = false;			  //Whether autoPVT is enabled or not
 	boolean autoPVTImplicitUpdate = true; // Whether autoPVT is triggered by accessing stale data (=true) or by a call to checkUblox (=false)
 	boolean commandAck = false;			  //This goes true after we send a command and it's ack'd
-	uint8_t ubxFrameCounter;
+	uint16_t ubxFrameCounter;			  //It counts all UBX frame. [Fixed header(2bytes), CLS(1byte), ID(1byte), length(2bytes), payload(x bytes), checksums(2bytes)]
 
 	uint8_t rollingChecksumA; //Rolls forward as we receive incoming bytes. Checked against the last two A/B checksum bytes
 	uint8_t rollingChecksumB; //Rolls forward as we receive incoming bytes. Checked against the last two A/B checksum bytes


### PR DESCRIPTION
It's first time to pull request on github for me.

When I use NEO-M8N module, and run the example #7 "GetProtcolVersion",
the version is shown as "0.0" instead of "18.0".

After straggling debug, I found the ubxFrameCounter is overflowed and rolling checksums are not correct.

When MON-VER is sent, NEO-M8N returns 260bytes UBX frame : 8bytes header, 250 bytes payload (40bytes soft/hard version and 7 x 30bytes extensions), and 2bytes checksums.
The default ubxFrameCounter is defined as uint8_t, so it counts till 255 and rollovers to 0 and checksums are reset.

I modified type of ubxFrameCounter from uint8_t to uint16_t.
It works fine!