### PR TITLE
Added checksumFailurePin

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -526,9 +526,12 @@ void SFE_UBLOX_GPS::processUBX(uint8_t incoming, ubxPacket *incomingUBX)
         debugPrintln((char *)"Checksum failed. Response too big?");
 
         //Drive an external pin to allow for easier logic analyzation
-        digitalWrite(2, LOW);
-        delay(10);
-        digitalWrite(2, HIGH);
+        if (checksumFailurePin >= 0)
+        {
+          digitalWrite((uint8_t)checksumFailurePin, LOW);
+          delay(10);
+          digitalWrite((uint8_t)checksumFailurePin, HIGH);
+        }
 
         _debugSerial->print(F("Size: "));
         _debugSerial->print(incomingUBX->len);

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -76,6 +76,10 @@
 #endif
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
+//Define a digital pin to aid checksum failure capture and analysis
+//Leave set to -1 if not needed
+const int checksumFailurePin = -1;
+
 //Registers
 const uint8_t UBX_SYNCH_1 = 0xB5;
 const uint8_t UBX_SYNCH_2 = 0x62;


### PR DESCRIPTION
Hi Nathan (@nseidle),
Currently, processUBX uses [Pin 2 to help diagnose checksum failures](https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library/blob/master/src/SparkFun_Ublox_Arduino_Library.cpp#L528-L531). This could cause problems for anyone using Pin 2 for other stuff - including SoftwareSerial in my case! ;-)
I suggest:
- Adding checksumFailurePin to the header file.
- Changing the digitalWrite in processUBX so it uses the checksumFailurePin (if defined) instead of having it hard-coded to Pin 2.

Instead of being `const int`, maybe checksumFailurePin should just be a regular `int` so it can be changed by the code in your .ino instead of involving editing the header file?
Or, you could really go to town on it and define a `setChecksumFailurePin()` function to change it?! But perhaps that's overkill...? ;-)
Enjoy!
Paul