### PR TITLE
Better ACK handling

### DIFF
--- a/examples/Example13_PVT/Example2_AutoPVT_ExplicitUpdate/Example2_AutoPVT_ExplicitUpdate.ino
+++ b/examples/Example13_PVT/Example2_AutoPVT_ExplicitUpdate/Example2_AutoPVT_ExplicitUpdate.ino
@@ -35,7 +35,8 @@ SFE_UBLOX_GPS myGPS;
 void setup()
 {
   Serial.begin(115200);
-  while (!Serial); //Wait for user to open terminal
+  while (!Serial)
+    ; //Wait for user to open terminal
   Serial.println("SparkFun Ublox Example");
 
   Wire.begin();
@@ -43,17 +44,18 @@ void setup()
   if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
   {
     Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
-    while (1);
+    while (1)
+      ;
   }
 
   myGPS.setI2COutput(COM_TYPE_UBX); //Set the I2C port to output UBX only (turn off NMEA noise)
-  myGPS.setNavigationFrequency(2); //Produce two solutions per second
-  myGPS.setAutoPVT(true, false); //Tell the GPS to "send" each solution and the lib not to update stale data implicitly
-  myGPS.saveConfiguration(); //Save the current settings to flash and BBR
+  myGPS.setNavigationFrequency(2);  //Produce two solutions per second
+  myGPS.setAutoPVT(true, false);    //Tell the GPS to "send" each solution and the lib not to update stale data implicitly
+  myGPS.saveConfiguration();        //Save the current settings to flash and BBR
 }
 
 /*
-     Calling getPVT would return false now (compare to Example 13 where it would return true), so we just use the data provided
+     Calling getPVT would return false now (compare to previous example where it would return true), so we just use the data provided
      If you are using a threaded OS eg. FreeRTOS on an ESP32, the explicit mode of autoPVT allows you to use the data provided on both cores and inside multiple threads
      The data update in background creates an inconsistent state, but that should not cause issues for most applications as they usually won't change the GPS location significantly within a 2Hz - 5Hz update rate.
      Also you could oversample (10Hz - 20Hz) the data to smooth out such issues...
@@ -62,12 +64,14 @@ void loop()
 {
   static uint16_t counter = 0;
 
-  if (counter % 10 == 0) {
+  if (counter % 10 == 0)
+  {
     // update your AHRS filter here for a ~100Hz update rate
     // GPS data will be quasi static but data from your IMU will be changing
   }
   // debug output each half second
-  if (counter % 500  == 0) {
+  if (counter % 500 == 0)
+  {
     Serial.println();
     long latitude = myGPS.getLatitude();
     Serial.print(F("Lat: "));
@@ -90,7 +94,8 @@ void loop()
     Serial.println();
   }
   // call checkUblox all 50ms to capture the gps data
-  if (counter % 50 == 0) {
+  if (counter % 50 == 0)
+  {
     myGPS.checkUblox();
   }
   delay(1);

--- a/examples/Example16_Nanosecond_MaxOutput/Example16_Nanosecond_MaxOutput.ino
+++ b/examples/Example16_Nanosecond_MaxOutput/Example16_Nanosecond_MaxOutput.ino
@@ -33,14 +33,14 @@ long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox m
 
 void setup()
 {
-  Serial.begin(500000); //Increase serial speed to maximize 
+  Serial.begin(500000); //Increase serial speed to maximize
   while (!Serial)
     ; //Wait for user to open terminal
   Serial.println("SparkFun Ublox Example");
 
   Wire.begin();
   Wire.setClock(400000);
-  
+
   if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
   {
     Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
@@ -53,18 +53,16 @@ void setup()
 
   //myGPS.enableDebugging(); //Enable debug messages over Serial (default)
 
-  myGPS.setNavigationFrequency(10); //Set output to 10 times a second
+  myGPS.setNavigationFrequency(10);           //Set output to 10 times a second
   byte rate = myGPS.getNavigationFrequency(); //Get the update rate of this module
   Serial.print("Current update rate:");
   Serial.println(rate);
-  
 }
 
 void loop()
 {
-  //Query module only every second. Doing it more often will just cause I2C traffic.
-  //The module only responds when a new position is available
-  if (millis() - lastTime > 10)
+  // Calling getPVT returns true if there actually is a fresh navigation solution available.
+  if (myGPS.getPVT())
   {
     lastTime = millis(); //Update the timer
 
@@ -86,6 +84,7 @@ void loop()
     Serial.print(F(" SIV: "));
     Serial.print(SIV);
 
+    Serial.print(" ");
     Serial.print(myGPS.getYear());
     Serial.print("-");
     Serial.print(myGPS.getMonth());
@@ -99,6 +98,8 @@ void loop()
     Serial.print(myGPS.getSecond());
     Serial.print(".");
     Serial.print(myGPS.getNanosecond());
+
+    myGPS.flushPVT();
 
     Serial.println();
   }

--- a/examples/Example16_PartialSecond_MaxOutput/Example16_PartialSecond_MaxOutput.ino
+++ b/examples/Example16_PartialSecond_MaxOutput/Example16_PartialSecond_MaxOutput.ino
@@ -32,14 +32,14 @@ long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox m
 
 void setup()
 {
-  Serial.begin(500000); //Increase serial speed to maximize 
+  Serial.begin(500000); //Increase serial speed to maximize
   while (!Serial)
     ; //Wait for user to open terminal
   Serial.println("SparkFun Ublox Example");
 
   Wire.begin();
   Wire.setClock(400000);
-  
+
   if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
   {
     Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
@@ -51,12 +51,12 @@ void setup()
 
   //myGPS.enableDebugging(); //Enable debug messages over Serial (default)
 
-  myGPS.setNavigationFrequency(10); //Set output to 10 times a second
+  myGPS.setNavigationFrequency(10);           //Set output to 10 times a second
   byte rate = myGPS.getNavigationFrequency(); //Get the update rate of this module
   Serial.print("Current update rate:");
   Serial.println(rate);
-  
-  myGPS.saveConfiguration();        //Save the current settings to flash and BBR
+
+  myGPS.saveConfiguration(); //Save the current settings to flash and BBR
 
   pinMode(2, OUTPUT); //For debug capture
   digitalWrite(2, HIGH);
@@ -64,8 +64,8 @@ void setup()
 
 void loop()
 {
-  //Query module very often to get max update rate
-  if (millis() - lastTime > 10)
+  // Calling getPVT returns true if there actually is a fresh navigation solution available.
+  if (myGPS.getPVT())
   {
     lastTime = millis(); //Update the timer
 
@@ -102,11 +102,13 @@ void loop()
     Serial.print(".");
     //Pretty print leading zeros
     int mseconds = myGPS.getMillisecond();
-    if(mseconds < 100) Serial.print("0");
-    if(mseconds < 10) Serial.print("0");
+    if (mseconds < 100)
+      Serial.print("0");
+    if (mseconds < 10)
+      Serial.print("0");
     Serial.print(mseconds);
 
-    Serial.print(" nanoSeconds: ");    
+    Serial.print(" nanoSeconds: ");
     Serial.print(myGPS.getNanosecond());
 
     Serial.println();

--- a/keywords.txt
+++ b/keywords.txt
@@ -102,6 +102,7 @@ debugPrintln	KEYWORD2
 factoryReset	KEYWORD2
 setAutoPVT	KEYWORD2
 assumeAutoPVT	KEYWORD2
+flushPVT	KEYWORD2
 
 getYear	KEYWORD2
 getMonth	KEYWORD2

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -279,7 +279,7 @@ boolean SFE_UBLOX_GPS::checkUbloxI2C()
       if (lsb == 0xFF)
       {
         //I believe this is a Ublox bug. Device should never present an 0xFF.
-        debugPrintln((char *)"checkUbloxI2C: Ublox bug, no bytes available");
+        debugPrintln((char *)F("checkUbloxI2C: Ublox bug, no bytes available"));
         lastCheck = millis(); //Put off checking to avoid I2C bus traffic
         return (false);
       }
@@ -288,7 +288,7 @@ boolean SFE_UBLOX_GPS::checkUbloxI2C()
 
     if (bytesAvailable == 0)
     {
-      debugPrintln((char *)"checkUbloxI2C: OK, zero bytes available");
+      debugPrintln((char *)F("checkUbloxI2C: OK, zero bytes available"));
       lastCheck = millis(); //Put off checking to avoid I2C bus traffic
       return (false);
     }
@@ -345,7 +345,7 @@ boolean SFE_UBLOX_GPS::checkUbloxI2C()
           {
             if (incoming == 0x7F)
             {
-              debugPrintln((char *)"Module not ready with data");
+              debugPrintln((char *)F("Module not ready with data"));
               delay(5); //In logic analyzation, the module starting responding after 1.48ms
               goto TRY_AGAIN;
             }
@@ -573,9 +573,9 @@ void SFE_UBLOX_GPS::processUBX(uint8_t incoming, ubxPacket *incomingUBX)
         printPacket(incomingUBX);
 
         if (packetCfg.valid == true)
-          debugPrintln((char *)"packetCfg now valid");
+          debugPrintln((char *)F("packetCfg now valid"));
         if (packetAck.valid == true)
-          debugPrintln((char *)"packetAck now valid");
+          debugPrintln((char *)F("packetAck now valid"));
       }
 
       processUBXpacket(incomingUBX); //We've got a valid packet, now do something with it
@@ -592,7 +592,7 @@ void SFE_UBLOX_GPS::processUBX(uint8_t incoming, ubxPacket *incomingUBX)
           digitalWrite((uint8_t)checksumFailurePin, HIGH);
         }
 
-        debugPrint((char *)"Checksum failed:");
+        debugPrint((char *)F("Checksum failed:"));
         _debugSerial->print(F(" checksumA: "));
         _debugSerial->print(incomingUBX->checksumA);
         _debugSerial->print(F(" checksumB: "));
@@ -640,13 +640,13 @@ void SFE_UBLOX_GPS::processUBXpacket(ubxPacket *msg)
     if (msg->id == UBX_ACK_ACK && msg->payload[0] == packetCfg.cls && msg->payload[1] == packetCfg.id)
     {
       //The ack we just received matched the CLS/ID of last packetCfg sent (or received)
-      debugPrintln((char *)"UBX ACK: Command sent/ack'd successfully");
+      debugPrintln((char *)F("UBX ACK: Command sent/ack'd successfully"));
       commandAck = UBX_ACK_ACK;
     }
     else if (msg->id == UBX_ACK_NACK && msg->payload[0] == packetCfg.cls && msg->payload[1] == packetCfg.id)
     {
       //The ack we just received matched the CLS/ID of last packetCfg sent
-      debugPrintln((char *)"UBX ACK: Not-Acknowledged");
+      debugPrintln((char *)F("UBX ACK: Not-Acknowledged"));
       commandAck = UBX_ACK_NACK;
     }
     break;
@@ -771,7 +771,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::sendCommand(ubxPacket outgoingUBX, uint16_t ma
     retVal = sendI2cCommand(outgoingUBX, maxWait);
     if (retVal != SFE_UBLOX_STATUS_SUCCESS)
     {
-      debugPrintln((char *)"Send I2C Command failed");
+      debugPrintln((char *)F("Send I2C Command failed"));
       return retVal;
     }
   }
@@ -785,12 +785,12 @@ sfe_ublox_status_e SFE_UBLOX_GPS::sendCommand(ubxPacket outgoingUBX, uint16_t ma
     //Depending on what we just sent, either we need to look for an ACK or not
     if (outgoingUBX.cls == UBX_CLASS_CFG)
     {
-      debugPrintln((char *)"sendCommand: Waiting for ACK response");
+      debugPrintln((char *)F("sendCommand: Waiting for ACK response"));
       retVal = waitForACKResponse(outgoingUBX.cls, outgoingUBX.id, maxWait); //Wait for Ack response
     }
     else
     {
-      debugPrintln((char *)"sendCommand: Waiting for No ACK response");
+      debugPrintln((char *)F("sendCommand: Waiting for No ACK response"));
       retVal = waitForNoACKResponse(outgoingUBX.cls, outgoingUBX.id, maxWait); //Wait for Ack response
     }
   }
@@ -1025,21 +1025,21 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForACKResponse(uint8_t requestedClass, uin
             else
             {
               //Reset packet and continue checking incoming data for matching cls/id
-              debugPrintln((char *)"waitForACKResponse: CLS/ID mismatch, continue to wait...");
+              debugPrintln((char *)F("waitForACKResponse: CLS/ID mismatch, continue to wait..."));
               packetCfg.valid = false; //This will go true when we receive a response to the packet we sent
             }
           }
           else
           {
             //We were expecting data but didn't get a valid config packet
-            debugPrintln((char *)"waitForACKResponse: Invalid config packet");
+            debugPrintln((char *)F("waitForACKResponse: Invalid config packet"));
             return (SFE_UBLOX_STATUS_FAIL); //We got an ACK, we're never going to get valid config data
           }
         }
         else
         {
           //We have sent new data. We expect an ACK but no return config packet.
-          debugPrintln((char *)"waitForACKResponse: New data successfully sent");
+          debugPrintln((char *)F("waitForACKResponse: New data successfully sent"));
           return (SFE_UBLOX_STATUS_DATA_SENT); //New data successfully sent
         }
       }
@@ -1062,7 +1062,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForACKResponse(uint8_t requestedClass, uin
   //Through debug warning, This command might not get an ACK
   if (packetCfg.valid == true)
   {
-    debugPrintln((char *)"waitForACKResponse: Config was valid but ACK not received");
+    debugPrintln((char *)F("waitForACKResponse: Config was valid but ACK not received"));
   }
 
   if (_printDebug == true)
@@ -1106,7 +1106,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForNoACKResponse(uint8_t requestedClass, u
         }
         else
         {
-          debugPrintln((char *)"waitForNoACKResponse: CLS/ID match but failed CRC");
+          debugPrintln((char *)F("waitForNoACKResponse: CLS/ID match but failed CRC"));
           return (SFE_UBLOX_STATUS_CRC_FAIL); //We got the right packet but it was corrupt
         }
       }
@@ -1115,7 +1115,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForNoACKResponse(uint8_t requestedClass, u
         //Reset packet and continue checking incoming data for matching cls/id
         if (_printDebug == true)
         {
-          debugPrint((char *)"waitForNoACKResponse: CLS/ID mismatch: ");
+          debugPrint((char *)F("waitForNoACKResponse: CLS/ID mismatch: "));
           _debugSerial->print(F("CLS: "));
           _debugSerial->print(packetCfg.cls, HEX);
           _debugSerial->print(F(" ID: "));
@@ -1681,7 +1681,7 @@ boolean SFE_UBLOX_GPS::setPortOutput(uint8_t portID, uint8_t outStreamSettings, 
 
   if (commandAck != UBX_ACK_ACK)
   {
-    debugPrintln((char *)"setPortOutput failed to ACK");
+    debugPrintln((char *)F("setPortOutput failed to ACK"));
     return (false);
   }
 
@@ -2072,7 +2072,7 @@ boolean SFE_UBLOX_GPS::powerSaveMode(bool power_save, uint16_t maxWait)
   */
   if (protVer >= 27)
   {
-    debugPrintln((char *)"powerSaveMode (UBX-CFG-RXM) is not supported by this protocol version");
+    debugPrintln((char *)F("powerSaveMode (UBX-CFG-RXM) is not supported by this protocol version"));
     return (false);
   }
 
@@ -2238,19 +2238,19 @@ boolean SFE_UBLOX_GPS::getPVT(uint16_t maxWait)
   if (autoPVT && autoPVTImplicitUpdate)
   {
     //The GPS is automatically reporting, we just check whether we got unread data
-    debugPrintln((char *)"getPVT: Autoreporting");
+    debugPrintln((char *)F("getPVT: Autoreporting"));
     checkUblox();
     return moduleQueried.all;
   }
   else if (autoPVT && !autoPVTImplicitUpdate)
   {
     //Someone else has to call checkUblox for us...
-    debugPrintln((char *)"getPVT: Exit immediately");
+    debugPrintln((char *)F("getPVT: Exit immediately"));
     return (false);
   }
   else
   {
-    debugPrintln((char *)"getPVT: Polling");
+    debugPrintln((char *)F("getPVT: Polling"));
 
     //The GPS is not automatically reporting navigation position so we have to poll explicitly
     packetCfg.cls = UBX_CLASS_NAV;

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -313,8 +313,8 @@ boolean SFE_UBLOX_GPS::checkUbloxI2C()
       if (_printDebug == true)
       {
         _debugSerial->print(F("checkUbloxI2C: Large packet of "));
-        _debugSerial->println(bytesAvailable);
-        _debugSerial->print(F("bytes received"));
+        _debugSerial->print(bytesAvailable);
+        _debugSerial->println(F(" bytes received"));
       }
     }
 

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -1706,10 +1706,6 @@ boolean SFE_UBLOX_GPS::setPortInput(uint8_t portID, uint8_t inStreamSettings, ui
   if (getPortSettings(portID, maxWait) == false)
     return (false); //Something went wrong. Bail.
 
-  // Let's make sure we wait for the ACK too (sendCommand will have returned as soon as the module sent its response)
-  // This is only required because we are doing two sendCommands in quick succession using the same class and ID
-  //waitForResponse(UBX_CLASS_CFG, UBX_CFG_PRT, 100); // But we'll only wait for 100msec max
-
   packetCfg.cls = UBX_CLASS_CFG;
   packetCfg.id = UBX_CFG_PRT;
   packetCfg.len = 20;
@@ -2085,10 +2081,6 @@ boolean SFE_UBLOX_GPS::powerSaveMode(bool power_save, uint16_t maxWait)
   if (sendCommand(packetCfg, maxWait) == false) //Ask module for the current power management settings. Loads into payloadCfg.
     return (false);
 
-  // Let's make sure we wait for the ACK too (sendCommand will have returned as soon as the module sent its response)
-  // This is only required because we are doing two sendCommands in quick succession using the same class and ID
-  //waitForResponse(UBX_CLASS_CFG, UBX_CFG_RXM, 100); // But we'll only wait for 100msec max
-
   if (power_save)
   {
     payloadCfg[1] = 1; // Power Save Mode
@@ -2119,10 +2111,6 @@ boolean SFE_UBLOX_GPS::setDynamicModel(dynModel newDynamicModel, uint16_t maxWai
 
   if (sendCommand(packetCfg, maxWait) == false) //Ask module for the current navigation model settings. Loads into payloadCfg.
     return (false);
-
-  // Let's make sure we wait for the ACK too (sendCommand will have returned as soon as the module sent its response)
-  // This is only required because we are doing two sendCommands in quick succession using the same class and ID
-  //waitForResponse(UBX_CLASS_CFG, UBX_CFG_NAV5, 100); // But we'll only wait for 100msec max
 
   payloadCfg[0] = 0x01;            // mask: set only the dyn bit (0)
   payloadCfg[1] = 0x00;            // mask

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -291,30 +291,30 @@ public:
 
 	boolean waitForResponse(uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = 250); //Poll the module until and ack is received
 
-  // getPVT will only return data once in each navigation cycle. By default, that is once per second.
-  // Therefore we should set getPVTmaxWait to slightly longer than that.
-  // If you change the navigation frequency to (e.g.) 4Hz using setNavigationFrequency(4)
-  // then you should use a shorter maxWait for getPVT. 300msec would be about right: getPVT(300)
-  // The same is true for getHPPOSLLH.
-  #define getPVTmaxWait 1100 // Default maxWait for getPVT and all functions which call it
-  #define getHPPOSLLHmaxWait 1100  // Default maxWait for getHPPOSLLH and all functions which call it
+// getPVT will only return data once in each navigation cycle. By default, that is once per second.
+// Therefore we should set getPVTmaxWait to slightly longer than that.
+// If you change the navigation frequency to (e.g.) 4Hz using setNavigationFrequency(4)
+// then you should use a shorter maxWait for getPVT. 300msec would be about right: getPVT(300)
+// The same is true for getHPPOSLLH.
+#define getPVTmaxWait 1100		// Default maxWait for getPVT and all functions which call it
+#define getHPPOSLLHmaxWait 1100 // Default maxWait for getHPPOSLLH and all functions which call it
 
-	boolean assumeAutoPVT(boolean enabled, boolean implicitUpdate = true); //In case no config access to the GPS is possible and PVT is send cyclically already
-	boolean setAutoPVT(boolean enabled, uint16_t maxWait = 250); //Enable/disable automatic PVT reports at the navigation frequency
-	boolean getPVT(uint16_t maxWait = getPVTmaxWait); //Query module for latest group of datums and load global vars: lat, long, alt, speed, SIV, accuracies, etc. If autoPVT is disabled, performs an explicit poll and waits, if enabled does not block. Retruns true if new PVT is available.
+	boolean assumeAutoPVT(boolean enabled, boolean implicitUpdate = true);				 //In case no config access to the GPS is possible and PVT is send cyclically already
+	boolean setAutoPVT(boolean enabled, uint16_t maxWait = 250);						 //Enable/disable automatic PVT reports at the navigation frequency
+	boolean getPVT(uint16_t maxWait = getPVTmaxWait);									 //Query module for latest group of datums and load global vars: lat, long, alt, speed, SIV, accuracies, etc. If autoPVT is disabled, performs an explicit poll and waits, if enabled does not block. Retruns true if new PVT is available.
 	boolean setAutoPVT(boolean enabled, boolean implicitUpdate, uint16_t maxWait = 250); //Enable/disable automatic PVT reports at the navigation frequency, with implicitUpdate == false accessing stale data will not issue parsing of data in the rxbuffer of your interface, instead you have to call checkUblox when you want to perform an update
-	boolean getHPPOSLLH(uint16_t maxWait = getHPPOSLLHmaxWait); //Query module for latest group of datums and load global vars: lat, long, alt, speed, SIV, accuracies, etc. If autoPVT is disabled, performs an explicit poll and waits, if enabled does not block. Retruns true if new PVT is available.
+	boolean getHPPOSLLH(uint16_t maxWait = getHPPOSLLHmaxWait);							 //Query module for latest group of datums and load global vars: lat, long, alt, speed, SIV, accuracies, etc. If autoPVT is disabled, performs an explicit poll and waits, if enabled does not block. Retruns true if new PVT is available.
 
-	int32_t getLatitude(uint16_t maxWait = getPVTmaxWait); //Returns the current latitude in degrees * 10^-7. Auto selects between HighPrecision and Regular depending on ability of module.
-	int32_t getLongitude(uint16_t maxWait = getPVTmaxWait); //Returns the current longitude in degrees * 10-7. Auto selects between HighPrecision and Regular depending on ability of module.
-	int32_t getAltitude(uint16_t maxWait = getPVTmaxWait); //Returns the current altitude in mm above ellipsoid
-	int32_t getAltitudeMSL(uint16_t maxWait = getPVTmaxWait); //Returns the current altitude in mm above mean sea level
-	uint8_t getSIV(uint16_t maxWait = getPVTmaxWait); //Returns number of sats used in fix
-	uint8_t getFixType(uint16_t maxWait = getPVTmaxWait); //Returns the type of fix: 0=no, 3=3D, 4=GNSS+Deadreckoning
+	int32_t getLatitude(uint16_t maxWait = getPVTmaxWait);			  //Returns the current latitude in degrees * 10^-7. Auto selects between HighPrecision and Regular depending on ability of module.
+	int32_t getLongitude(uint16_t maxWait = getPVTmaxWait);			  //Returns the current longitude in degrees * 10-7. Auto selects between HighPrecision and Regular depending on ability of module.
+	int32_t getAltitude(uint16_t maxWait = getPVTmaxWait);			  //Returns the current altitude in mm above ellipsoid
+	int32_t getAltitudeMSL(uint16_t maxWait = getPVTmaxWait);		  //Returns the current altitude in mm above mean sea level
+	uint8_t getSIV(uint16_t maxWait = getPVTmaxWait);				  //Returns number of sats used in fix
+	uint8_t getFixType(uint16_t maxWait = getPVTmaxWait);			  //Returns the type of fix: 0=no, 3=3D, 4=GNSS+Deadreckoning
 	uint8_t getCarrierSolutionType(uint16_t maxWait = getPVTmaxWait); //Returns RTK solution: 0=no, 1=float solution, 2=fixed solution
-	int32_t getGroundSpeed(uint16_t maxWait = getPVTmaxWait); //Returns speed in mm/s
-	int32_t getHeading(uint16_t maxWait = getPVTmaxWait); //Returns heading in degrees * 10^-7
-	uint16_t getPDOP(uint16_t maxWait = getPVTmaxWait); //Returns positional dillution of precision * 10^-2
+	int32_t getGroundSpeed(uint16_t maxWait = getPVTmaxWait);		  //Returns speed in mm/s
+	int32_t getHeading(uint16_t maxWait = getPVTmaxWait);			  //Returns heading in degrees * 10^-7
+	uint16_t getPDOP(uint16_t maxWait = getPVTmaxWait);				  //Returns positional dillution of precision * 10^-2
 	uint16_t getYear(uint16_t maxWait = getPVTmaxWait);
 	uint8_t getMonth(uint16_t maxWait = getPVTmaxWait);
 	uint8_t getDay(uint16_t maxWait = getPVTmaxWait);
@@ -393,10 +393,10 @@ public:
 
 	//Support for geofences
 	boolean addGeofence(int32_t latitude, int32_t longitude, uint32_t radius, byte confidence = 0, byte pinPolarity = 0, byte pin = 0, uint16_t maxWait = 1100); // Add a new geofence
-	boolean clearGeofences(uint16_t maxWait = 1100); //Clears all geofences
-	boolean getGeofenceState(geofenceState &currentGeofenceState, uint16_t maxWait = 1100); //Returns the combined geofence state
-	boolean clearAntPIO(uint16_t maxWait = 1100); //Clears the antenna control pin settings to release the PIOs
-	geofenceParams currentGeofenceParams; // Global to store the geofence parameters
+	boolean clearGeofences(uint16_t maxWait = 1100);																											 //Clears all geofences
+	boolean getGeofenceState(geofenceState &currentGeofenceState, uint16_t maxWait = 1100);																		 //Returns the combined geofence state
+	boolean clearAntPIO(uint16_t maxWait = 1100);																												 //Clears the antenna control pin settings to release the PIOs
+	geofenceParams currentGeofenceParams;																														 // Global to store the geofence parameters
 
 	boolean powerSaveMode(bool power_save = true, uint16_t maxWait = 1100);
 

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -289,7 +289,9 @@ public:
 	boolean saveConfiguration(uint16_t maxWait = 250);						 //Save current configuration to flash and BBR (battery backed RAM)
 	boolean factoryDefault(uint16_t maxWait = 250);							 //Reset module to factory defaults
 
-	boolean waitForResponse(uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = 250); //Poll the module until and ack is received
+	//boolean waitForResponse(uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = 250); //Poll the module until an ACK is received
+	boolean waitForACKResponse(uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = 250);   //Poll the module until a config packet and an ACK is received
+	boolean waitForNoACKResponse(uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = 250); //Poll the module until a config packet is received
 
 // getPVT will only return data once in each navigation cycle. By default, that is once per second.
 // Therefore we should set getPVTmaxWait to slightly longer than that.


### PR DESCRIPTION
This PR re-writes how we look for responses from sendCommand(). Instead of assume an ACK is valid we explicitly look for the correct ACK depending on the type of packet being sent. From the UBX datasheet:

> When messages from the class CFG are sent to the receiver, the receiver will send an "acknowledge"(UBX - ACK - ACK) or a "not acknowledge"(UBX-ACK-NAK) message back to the sender, depending on whether or not the message was processed correctly. Some messages from other classes also use the same acknowledgement mechanism.

For packets intended to re-configure the Ublox module, we look for an ACK but this is split into two cases:

1. We may be querying a setting in which case we expect the packetCfg to be filled with the current setting data, and then the UBX should send an ACK. These two cases must be achieved for waitForACKResponse to return success.
2. We may be sending new data into a setting in which case we expect an ACK but no data in packetCfg.

For packets intended to merely get data from the Ublox module (for example a PVT packet), we look for packetCfg to be filled but there will be no ACK. We use waitForNoACKResponse. For NoAck responses, we still verify that the CLS/ID of the incoming packet (think PVT) match what we asked for.

This PR generally improves the stability of the library. There are still plenty of ways to break it but it's working much better.

There were a few small changes:

* Many more debug statements to help follow the flow.
* Add flushPVT() to allow the marking of all PVT data as stale. Previously, if there was a CRC error PVT readings would get out of line. This method allows us to re-align the data each time we're done reading (for example after we've read lat, long, date, etc and are waiting for a 1000ms to expire).

Known issues: 

* The library has grown in size and complexity. We may need to re-think how debug statements are printed. Perhaps with #ifdef guards. Not great for the end user but I don't know of a better way to lighten the library.
* There is still I2C corruption using the Artemis platform. I'm still confused as to why the Ublox modules don't respect I2C setup times.
* The GeoFence example is still acting weird. It's a nice example of a whole bunch of configuration and readings going on so I have still included it but I know the various functions (addGeofence, clearGeofences, etc) work on their own.


