### PR TITLE
Added constant descriptions and added new constants for future use

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -120,31 +120,37 @@ const uint8_t UBX_CLASS_SEC = 0x27; //Security Feature Messages
 const uint8_t UBX_CLASS_HNR = 0x28; //(NEO-M8P ONLY!!!) High Rate Navigation Results Messages: High rate time, position speed, heading
 const uint8_t UBX_CLASS_NMEA = 0xF0; //NMEA Strings: standard NMEA strings
 
-
-const uint8_t UBX_CFG_PRT = 0x00;  //Used to configure port specifics
-const uint8_t UBX_CFG_RST = 0x04;  //Used to reset device
-const uint8_t UBX_CFG_RATE = 0x08; //Used to set port baud rates
-const uint8_t UBX_CFG_CFG = 0x09;  //Used to save current configuration
-const uint8_t UBX_CFG_RXM = 0x11;  //Used to set receiver power management (power save mode)
-const uint8_t UBX_CFG_NAV5 = 0x24; //Used to configure the navigation engine including the dynamic model
-
-const uint8_t UBX_CFG_VALSET = 0x8A; //Used for config of higher version Ublox modules (ie protocol v27 and above)
-const uint8_t UBX_CFG_VALGET = 0x8B; //Used for config of higher version Ublox modules (ie protocol v27 and above)
-const uint8_t UBX_CFG_VALDEL = 0x8C; //Used for config of higher version Ublox modules (ie protocol v27 and above)
-
-const uint8_t UBX_CFG_GEOFENCE = 0x69; //Used to configure a geofence
-const uint8_t UBX_CFG_ANT = 0x13;	  //Used to configure the antenna control settings
-const uint8_t UBX_NAV_GEOFENCE = 0x39; //Used to poll the geofence status
-
-const uint8_t UBX_CFG_TMODE3 = 0x71; //Used to enable Survey In Mode
-const uint8_t SVIN_MODE_DISABLE = 0x00;
-const uint8_t SVIN_MODE_ENABLE = 0x01;
-
-const uint8_t UBX_NAV_PVT = 0x07;		//All the things! Position, velocity, time, PDOP, height, h/v accuracies, number of satellites
-const uint8_t UBX_NAV_HPPOSECEF = 0x13; //Find our positional accuracy (high precision)
-const uint8_t UBX_NAV_HPPOSLLH = 0x14;  //Used for obtaining lat/long/alt in high precision
-const uint8_t UBX_NAV_SVIN = 0x3B;		//Used for checking Survey In status
-const uint8_t UBX_NAV_RELPOSNED = 0x3C; //Relative Positioning Information in NED frame
+//The following are used for configuration. Descriptions are from the ZED-F9P Interface Description pg 33-34 and NEO-M9N Interface Description pg 47-48
+const uint8_t UBX_CFG_ANT = 0x13; //Antenna Control Settings. Used to configure the antenna control settings
+const uint8_t UBX_CFG_BATCH = 0x93; //Get/set data batching configuration.
+const uint8_t UBX_CFG_CFG = 0x09; //Clear, Save, and Load Configurations. Used to save current configuration
+const uint8_t UBX_CFG_DAT = 0x06; //Set User-defined Datum or The currently defined Datum
+const uint8_t UBX_CFG_DGNSS = 0x70; //DGNSS configuration
+const uint8_t UBX_CFG_GEOFENCE = 0x69; //Geofencing configuration. Used to configure a geofence
+const uint8_t UBX_CFG_GNSS = 0x3E; //GNSS system configuration
+const uint8_t UBX_CFG_INF = 0x02; //Depending on packet length, either: poll configuration for one protocol, or information message configuration
+const uint8_t UBX_CFG_ITFM = 0x39; //Jamming/Interference Monitor configuration
+const uint8_t UBX_CFG_LOGFILTER = 0x47; //Data Logger Configuration
+const uint8_t UBX_CFG_MSG = 0x01; //Poll a message configuration, or Set Message Rate(s), or Set Message Rate
+const uint8_t UBX_CFG_NAV5 = 0x24; //Navigation Engine Settings. Used to configure the navigation engine including the dynamic model.
+const uint8_t UBX_CFG_NAVX5 = 0x23; //Navigation Engine Expert Settings
+const uint8_t UBX_CFG_NMEA = 0x17; //Extended NMEA protocol configuration V1
+const uint8_t UBX_CFG_ODO = 0x1E; //Odometer, Low-speed COG Engine Settings
+const uint8_t UBX_CFG_PM2 = 0x3B; //Extended power management configuration
+const uint8_t UBX_CFG_PMS = 0x86; //Power mode setup
+const uint8_t UBX_CFG_PRT = 0x00; //Used to configure port specifics. Polls the configuration for one I/O Port, or Port configuration for UART ports, or Port configuration for USB port, or Port configuration for SPI port, or Port configuration for DDC port
+const uint8_t UBX_CFG_PWR = 0x57; //Put receiver in a defined power state
+const uint8_t UBX_CFG_RATE = 0x08; //Navigation/Measurement Rate Settings. Used to set port baud rates.
+const uint8_t UBX_CFG_RINV = 0x34; //Contents of Remote Inventory
+const uint8_t UBX_CFG_RST = 0x04; //Reset Receiver / Clear Backup Data Structures. Used to reset device. 
+const uint8_t UBX_CFG_RXM = 0x11; //RXM configuration
+const uint8_t UBX_CFG_SBAS = 0x16; //SBAS configuration
+const uint8_t UBX_CFG_TMODE3 = 0x71; //Time Mode Settings 3. Used to enable Survey In Mode
+const uint8_t UBX_CFG_TP5 = 0x31; //Time Pulse Parameters
+const uint8_t UBX_CFG_USB = 0x1B; //USB Configuration
+const uint8_t UBX_CFG_VALDEL = 0x8C; //Used for config of higher version Ublox modules (ie protocol v27 and above). Deletes values corresponding to provided keys/ provided keys with a transaction
+const uint8_t UBX_CFG_VALGET = 0x8B; //Used for config of higher version Ublox modules (ie protocol v27 and above). Configuration Items
+const uint8_t UBX_CFG_VALSET = 0x8A; //Used for config of higher version Ublox modules (ie protocol v27 and above). Sets values corresponding to provided key-value pairs/ provided key-value pairs within a transaction.
 
 //The following are used to enable NMEA messages. Descriptions come from the NMEA messages overview in the ZED-F9P Interface Description
 const uint8_t UBX_NMEA_MSB = 0xF0; //All NMEA enable commands have 0xF0 as MSB
@@ -168,9 +174,6 @@ const uint8_t UBX_NMEA_VLW = 0x0F; //GxVLW (dual ground/water distance)
 const uint8_t UBX_NMEA_VTG = 0x05; //GxVTG (course over ground and Ground speed)
 const uint8_t UBX_NMEA_ZDA = 0x08; //GxZDA (Time and Date)
 
-const uint8_t UBX_MON_VER = 0x04;   //Used for obtaining Protocol Version
-const uint8_t UBX_MON_TXBUF = 0x08; //Used for query tx buffer size/state
-
 //The following are used to configure the NMEA protocol main talker ID and GSV talker ID
 const uint8_t UBX_NMEA_MAINTALKERID_NOTOVERRIDDEN = 0x00; //main talker ID is system dependent
 const uint8_t UBX_NMEA_MAINTALKERID_GP = 0x01; //main talker ID is GPS
@@ -192,8 +195,8 @@ const uint8_t UBX_INF_WARNING = 0x01; //ASCII output with warning contents
 //The following are used to configure LOG UBX messages (loggings messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
 const uint8_t UBX_LOG_CREATE = 0x07; //Create Log File
 const uint8_t UBX_LOG_ERASE = 0x03; //Erase Logged Data
-const uint8_t UBX_LOG_FINDTIME = 0x0E; //Depending on packet length, either: Find index of a log entry based on a..., or response to FINDTIME requested
-const uint8_t UBX_LOG_INFO = 0x08; //Depending on packet length, either: Poll for log information, or Log information
+const uint8_t UBX_LOG_FINDTIME = 0x0E; //Find index of a log entry based on a given time, or response to FINDTIME requested
+const uint8_t UBX_LOG_INFO = 0x08; //Poll for log information, or Log information
 const uint8_t UBX_LOG_RETRIEVEPOSEXTRA = 0x0F; //Odometer log entry
 const uint8_t UBX_LOG_RETRIEVEPOS = 0x0B; //Position fix log entry
 const uint8_t UBX_LOG_RETRIEVESTRING = 0x0D; //Byte string log entry
@@ -207,7 +210,7 @@ const uint8_t UBX_MGA_BDS_ALM = 0x03; //BDS Almanac Assistance
 const uint8_t UBX_MGA_BDS_HEALTH = 0x03; //BDS Health Assistance
 const uint8_t UBX_MGA_BDS_UTC = 0x03; //BDS UTC Assistance
 const uint8_t UBX_MGA_BDS_IONO = 0x03; //BDS Ionospheric Assistance
-const uint8_t UBX_MGA_DBD = 0x80; //Depending on packet length, either: Poll the Navigation Database, or Navigation Database Dump Entry
+const uint8_t UBX_MGA_DBD = 0x80; //Either: Poll the Navigation Database, or Navigation Database Dump Entry
 const uint8_t UBX_MGA_GAL_EPH = 0x02; //Galileo Ephemeris Assistance
 const uint8_t UBX_MGA_GAL_ALM = 0x02; //Galileo Almanac Assitance
 const uint8_t UBX_MGA_GAL_TIMOFFSET = 0x02; //Galileo GPS time offset assistance
@@ -243,27 +246,27 @@ const uint8_t UBX_MON_PATCH = 0x27; //Output information about installed patches
 const uint8_t UBX_MON_RF = 0x38; //RF information
 const uint8_t UBX_MON_RXBUF = 0x07; //Receiver Buffer Status
 const uint8_t UBX_MON_RXR = 0x21; //Receiver Status Information
-const uint8_t UBX_MON_TXBUF = 0x08; //Transmitter Buffer Status
-const uint8_t UBX_MON_VER = 0x04; //Receiver/Software Version
+const uint8_t UBX_MON_TXBUF = 0x08; //Transmitter Buffer Status. Used for query tx buffer size/state.
+const uint8_t UBX_MON_VER = 0x04; //Receiver/Software Version. Used for obtaining Protocol Version.
 
 //The following are used to configure the NAV UBX messages (navigation results messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 35-36)
 const uint8_t UBX_NAV_CLOCK = 0x22; //Clock Solution
 const uint8_t UBX_NAV_DOP = 0x04; //Dilution of precision
 const uint8_t UBX_NAV_EOE = 0x61; //End of Epoch
-const uint8_t UBX_NAV_GEOFENCE = 0x39; //Geofencing status
-const uint8_t UBX_NAV_HPPOSECEF = 0x13; //High Precision Position Solution in ECEF
-const uint8_t UBX_NAV_HPPOSLLH = 0x14; //High Precision Geodetic Position Solution
+const uint8_t UBX_NAV_GEOFENCE = 0x39; //Geofencing status. Used to poll the geofence status
+const uint8_t UBX_NAV_HPPOSECEF = 0x13; //High Precision Position Solution in ECEF. Used to find our positional accuracy (high precision).
+const uint8_t UBX_NAV_HPPOSLLH = 0x14; //High Precision Geodetic Position Solution. Used for obtaining lat/long/alt in high precision
 const uint8_t UBX_NAV_ODO = 0x09; //Odometer Solution
 const uint8_t UBX_NAV_ORB = 0x34; //GNSS Orbit Database Info
 const uint8_t UBX_NAV_POSECEF = 0x01; //Position Solution in ECEF
 const uint8_t UBX_NAV_POSLLH = 0x02; //Geodetic Position Solution
-const uint8_t UBX_NAV_PVT = 0x07; //Navigation Position Velocity Time Solution
+const uint8_t UBX_NAV_PVT = 0x07; //All the things! Position, velocity, time, PDOP, height, h/v accuracies, number of satellites. Navigation Position Velocity Time Solution.
 const uint8_t UBX_NAV_RELPOSNED = 0x3C; //Relative Positioning Information in NED frame
 const uint8_t UBX_NAV_RESETODO = 0x10; //Reset odometer
 const uint8_t UBX_NAV_SAT = 0x35; //Satellite Information
 const uint8_t UBX_NAV_SIG = 0x43; //Signal Information
 const uint8_t UBX_NAV_STATUS = 0x03; //Receiver Navigation Status
-const uint8_t UBX_NAV_SVIN = 0x3B; //Survey-in data
+const uint8_t UBX_NAV_SVIN = 0x3B; //Survey-in data. Used for checking Survey In status
 const uint8_t UBX_NAV_TIMEBDS = 0x24; //BDS Time Solution
 const uint8_t UBX_NAV_TIMEGAL = 0x25; //Galileo Time Solution
 const uint8_t UBX_NAV_TIMEGLO = 0x23; //GLO Time Solution
@@ -290,8 +293,7 @@ const uint8_t UBX_TIM_TP = 0x01; //Time Pulse Timedata
 const uint8_t UBX_TIM_VRFY = 0x06; //Sourced Time Verification
 
 //The following are used to configure the UPD UBX messages (firmware update messages). Descriptions from UBX messages overview (ZED-F9P Interface Description Document page 36)
-const uint8_t UBX_UPD_SOS = 0x14; //Different based on message size (Poll Backup Fil Restore Status, Create Backup File in Flash, Clear Backup File in Flash, Backup File Creation Acknowledge, System Restored from Backup
-
+const uint8_t UBX_UPD_SOS = 0x14; //Poll Backup Fil Restore Status, Create Backup File in Flash, Clear Backup File in Flash, Backup File Creation Acknowledge, System Restored from Backup
 
 
 //The following are used to enable RTCM messages
@@ -309,6 +311,10 @@ const uint8_t UBX_RTCM_1230 = 0xE6; //GLONASS code-phase biases, set to once eve
 const uint8_t UBX_ACK_NACK = 0x00;
 const uint8_t UBX_ACK_ACK = 0x01;
 const uint8_t UBX_ACK_NONE = 0x02; //Not a real value
+
+
+const uint8_t SVIN_MODE_DISABLE = 0x00;
+const uint8_t SVIN_MODE_ENABLE = 0x01;
 
 //The following consts are used to configure the various ports and streams for those ports. See -CFG-PRT.
 const uint8_t COM_PORT_I2C = 0;

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -103,21 +103,23 @@ typedef enum
 const uint8_t UBX_SYNCH_1 = 0xB5;
 const uint8_t UBX_SYNCH_2 = 0x62;
 
-const uint8_t UBX_CLASS_NAV = 0x01;
-const uint8_t UBX_CLASS_RXM = 0x02;
-const uint8_t UBX_CLASS_INF = 0x04;
-const uint8_t UBX_CLASS_ACK = 0x05;
-const uint8_t UBX_CLASS_CFG = 0x06;
-const uint8_t UBX_CLASS_UPD = 0x09;
-const uint8_t UBX_CLASS_MON = 0x0A;
-const uint8_t UBX_CLASS_AID = 0x0B;
-const uint8_t UBX_CLASS_TIM = 0x0D;
-const uint8_t UBX_CLASS_ESF = 0x10;
-const uint8_t UBX_CLASS_MGA = 0x13;
-const uint8_t UBX_CLASS_LOG = 0x21;
-const uint8_t UBX_CLASS_SEC = 0x27;
-const uint8_t UBX_CLASS_HNR = 0x28;
-const uint8_t UBX_CLASS_NMEA = 0xF0;
+//The following are UBX Class IDs. Descriptions taken from ZED-F9P Interface Description Document page 32, NEO-M8P Interface Description page 145
+const uint8_t UBX_CLASS_NAV = 0x01; //Navigation Results Messages: Position, Speed, Time, Acceleration, Heading, DOP, SVs used
+const uint8_t UBX_CLASS_RXM = 0x02; //Receiver Manager Messages: Satellite Status, RTC Status
+const uint8_t UBX_CLASS_INF = 0x04; //Information Messages: Printf-Style Messages, with IDs such as Error, Warning, Notice
+const uint8_t UBX_CLASS_ACK = 0x05; //Ack/Nak Messages: Acknowledge or Reject messages to UBX-CFG input messages
+const uint8_t UBX_CLASS_CFG = 0x06; //Configuration Input Messages: Configure the receiver.
+const uint8_t UBX_CLASS_UPD = 0x09; //Firmware Update Messages: Memory/Flash erase/write, Reboot, Flash identification, etc.
+const uint8_t UBX_CLASS_MON = 0x0A; //Monitoring Messages: Communication Status, CPU Load, Stack Usage, Task Status
+const uint8_t UBX_CLASS_AID = 0x0B; //(NEO-M8P ONLY!!!) AssistNow Aiding Messages: Ephemeris, Almanac, other A-GPS data input
+const uint8_t UBX_CLASS_TIM = 0x0D; //Timing Messages: Time Pulse Output, Time Mark Results
+const uint8_t UBX_CLASS_ESF = 0x10; //(NEO-M8P ONLY!!!) External Sensor Fusion Messages: External Sensor Measurements and Status Information
+const uint8_t UBX_CLASS_MGA = 0x13; //Multiple GNSS Assistance Messages: Assistance data for various GNSS
+const uint8_t UBX_CLASS_LOG = 0x21; //Logging Messages: Log creation, deletion, info and retrieval
+const uint8_t UBX_CLASS_SEC = 0x27; //Security Feature Messages
+const uint8_t UBX_CLASS_HNR = 0x28; //(NEO-M8P ONLY!!!) High Rate Navigation Results Messages: High rate time, position speed, heading
+const uint8_t UBX_CLASS_NMEA = 0xF0; //NMEA Strings: standard NMEA strings
+
 
 const uint8_t UBX_CFG_PRT = 0x00;  //Used to configure port specifics
 const uint8_t UBX_CFG_RST = 0x04;  //Used to reset device
@@ -144,19 +146,153 @@ const uint8_t UBX_NAV_HPPOSLLH = 0x14;  //Used for obtaining lat/long/alt in hig
 const uint8_t UBX_NAV_SVIN = 0x3B;		//Used for checking Survey In status
 const uint8_t UBX_NAV_RELPOSNED = 0x3C; //Relative Positioning Information in NED frame
 
-const uint8_t UBX_NMEA_GGA = 0x00;
-const uint8_t UBX_NMEA_GLL = 0x01;
-const uint8_t UBX_NMEA_GNS = 0x0D;
-const uint8_t UBX_NMEA_GRS = 0x06;
-const uint8_t UBX_NMEA_GSA = 0x02;
-const uint8_t UBX_NMEA_GST = 0x07;
-const uint8_t UBX_NMEA_GSV = 0x03;
-const uint8_t UBX_NMEA_RMC = 0x04;
-const uint8_t UBX_NMEA_VTG = 0x05;
-const uint8_t UBX_NMEA_ZDA = 0x08;
+//The following are used to enable NMEA messages. Descriptions come from the NMEA messages overview in the ZED-F9P Interface Description
+const uint8_t UBX_NMEA_MSB = 0xF0; //All NMEA enable commands have 0xF0 as MSB
+const uint8_t UBX_NMEA_DTM = 0x0A; //GxDTM (datum reference)
+const uint8_t UBX_NMEA_GAQ = 0x45; //GxGAQ (poll a standard message (if the current talker ID is GA))
+const uint8_t UBX_NMEA_GBQ = 0x44; //GxGBQ (poll a standard message (if the current Talker ID is GB))
+const uint8_t UBX_NMEA_GBS = 0x09; //GxGBS (GNSS satellite fault detection)
+const uint8_t UBX_NMEA_GGA = 0x00; //GxGGA (Global positioning system fix data)
+const uint8_t UBX_NMEA_GLL = 0x01; //GxGLL (latitude and long, whith time of position fix and status)
+const uint8_t UBX_NMEA_GLQ = 0x43; //GxGLQ (poll a standard message (if the current Talker ID is GL))
+const uint8_t UBX_NMEA_GNQ = 0x42; //GxGNQ (poll a standard message (if the current Talker ID is GN))
+const uint8_t UBX_NMEA_GNS = 0x0D; //GxGNS (GNSS fix data)
+const uint8_t UBX_NMEA_GPQ = 0x040; //GxGPQ (poll a standard message (if the current Talker ID is GP))
+const uint8_t UBX_NMEA_GRS = 0x06; //GxGRS (GNSS range residuals)
+const uint8_t UBX_NMEA_GSA = 0x02; //GxGSA (GNSS DOP and Active satellites)
+const uint8_t UBX_NMEA_GST = 0x07; //GxGST (GNSS Pseudo Range Error Statistics)
+const uint8_t UBX_NMEA_GSV = 0x03; //GxGSV (GNSS satellites in view)
+const uint8_t UBX_NMEA_RMC = 0x04; //GxRMC (Recommended minimum data)
+const uint8_t UBX_NMEA_TXT = 0x41; //GxTXT (text transmission)
+const uint8_t UBX_NMEA_VLW = 0x0F; //GxVLW (dual ground/water distance)
+const uint8_t UBX_NMEA_VTG = 0x05; //GxVTG (course over ground and Ground speed)
+const uint8_t UBX_NMEA_ZDA = 0x08; //GxZDA (Time and Date)
 
 const uint8_t UBX_MON_VER = 0x04;   //Used for obtaining Protocol Version
 const uint8_t UBX_MON_TXBUF = 0x08; //Used for query tx buffer size/state
+
+//The following are used to configure the NMEA protocol main talker ID and GSV talker ID
+const uint8_t UBX_NMEA_MAINTALKERID_NOTOVERRIDDEN = 0x00; //main talker ID is system dependent
+const uint8_t UBX_NMEA_MAINTALKERID_GP = 0x01; //main talker ID is GPS
+const uint8_t UBX_NMEA_MAINTALKERID_GL = 0x02; //main talker ID is GLONASS
+const uint8_t UBX_NMEA_MAINTALKERID_GN = 0x03; //main talker ID is combined receiver
+const uint8_t UBX_NMEA_MAINTALKERID_GA = 0x04; //main talker ID is Galileo
+const uint8_t UBX_NMEA_MAINTALKERID_GB = 0x05; //main talker ID is BeiDou
+const uint8_t UBX_NMEA_GSVTALKERID_GNSS = 0x00; //GNSS specific Talker ID (as defined by NMEA)
+const uint8_t UBX_NMEA_GSVTALKERID_MAIN = 0x01; //use the main Talker ID
+
+//The following are used to configure INF UBX messages (information messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
+const uint8_t UBX_INF_CLASS = 0x04; //All INF messages have 0x04 as the class
+const uint8_t UBX_INF_DEBUG = 0x04; //ASCII output with debug contents
+const uint8_t UBX_INF_ERROR = 0x00; //ASCII output with error contents
+const uint8_t UBX_INF_NOTICE = 0x02; //ASCII output with informational contents
+const uint8_t UBX_INF_TEST = 0x03; //ASCII output with test contents
+const uint8_t UBX_INF_WARNING = 0x01; //ASCII output with warning contents
+
+//The following are used to configure LOG UBX messages (loggings messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
+const uint8_t UBX_LOG_CREATE = 0x07; //Create Log File
+const uint8_t UBX_LOG_ERASE = 0x03; //Erase Logged Data
+const uint8_t UBX_LOG_FINDTIME = 0x0E; //Depending on packet length, either: Find index of a log entry based on a..., or response to FINDTIME requested
+const uint8_t UBX_LOG_INFO = 0x08; //Depending on packet length, either: Poll for log information, or Log information
+const uint8_t UBX_LOG_RETRIEVEPOSEXTRA = 0x0F; //Odometer log entry
+const uint8_t UBX_LOG_RETRIEVEPOS = 0x0B; //Position fix log entry
+const uint8_t UBX_LOG_RETRIEVESTRING = 0x0D; //Byte string log entry
+const uint8_t UBX_LOG_RETRIEVE = 0x09; //Request log data
+const uint8_t UBX_LOG_STRING = 0x04; //Store arbitrary string on on-board flash
+
+//The following are used to configure MGA UBX messages (Multiple GNSS Assistance Messages).  Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 34)
+const uint8_t UBX_MGA_ACK_DATA0 = 0x60;  //Multiple GNSS Acknowledge message
+const uint8_t UBX_MGA_BDS_EPH = 0x03; //BDS Ephemeris Assistance
+const uint8_t UBX_MGA_BDS_ALM = 0x03; //BDS Almanac Assistance
+const uint8_t UBX_MGA_BDS_HEALTH = 0x03; //BDS Health Assistance
+const uint8_t UBX_MGA_BDS_UTC = 0x03; //BDS UTC Assistance
+const uint8_t UBX_MGA_BDS_IONO = 0x03; //BDS Ionospheric Assistance
+const uint8_t UBX_MGA_DBD = 0x80; //Depending on packet length, either: Poll the Navigation Database, or Navigation Database Dump Entry
+const uint8_t UBX_MGA_GAL_EPH = 0x02; //Galileo Ephemeris Assistance
+const uint8_t UBX_MGA_GAL_ALM = 0x02; //Galileo Almanac Assitance
+const uint8_t UBX_MGA_GAL_TIMOFFSET = 0x02; //Galileo GPS time offset assistance
+const uint8_t UBX_MGA_GAL_UTC = 0x02; //Galileo UTC Assistance
+const uint8_t UBX_MGA_GLO_EPH = 0x06; //GLONASS Ephemeris Assistance
+const uint8_t UBX_MGA_GLO_ALM = 0x06; //GLONASS Almanac Assistance
+const uint8_t UBX_MGA_GLO_TIMEOFFSET = 0x06; //GLONASS Auxiliary Time Offset Assistance
+const uint8_t UBX_MGA_GPS_EPH = 0x00; //GPS Ephemeris Assistance
+const uint8_t UBX_MGA_GPS_ALM = 0x00; //GPS Almanac Assistance
+const uint8_t UBX_MGA_GPS_HEALTH = 0x00; //GPS Health Assistance
+const uint8_t UBX_MGA_GPS_UTC = 0x00; //GPS UTC Assistance
+const uint8_t UBX_MGA_GPS_IONO = 0x00; //GPS Ionosphere Assistance
+const uint8_t UBX_MGA_INI_POS_XYZ = 0x40; //Initial Position Assistance
+const uint8_t UBX_MGA_INI_POS_LLH = 0x40; //Initial Position Assitance
+const uint8_t UBX_MGA_INI_TIME_UTC = 0x40; //Initial Time Assistance
+const uint8_t UBX_MGA_INI_TIME_GNSS = 0x40; //Initial Time Assistance
+const uint8_t UBX_MGA_INI_CLKD = 0x40; //Initial Clock Drift Assitance
+const uint8_t UBX_MGA_INI_FREQ = 0x40; //Initial Frequency Assistance
+const uint8_t UBX_MGA_INI_EOP = 0x40; //Earth Orientation Parameters Assistance
+const uint8_t UBX_MGA_QZSS_EPH = 0x05; //QZSS Ephemeris Assistance
+const uint8_t UBX_MGA_QZSS_ALM = 0x05; //QZSS Almanac Assistance
+const uint8_t UBX_MGA_QZAA_HEALTH = 0x05; //QZSS Health Assistance
+
+//The following are used to configure the MON UBX messages (monitoring messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 35)
+const uint8_t UBX_MON_COMMS = 0x36; //Comm port information
+const uint8_t UBX_MON_GNSS = 0x28; //Information message major GNSS selection
+const uint8_t UBX_MON_HW2 = 0x0B; //Extended Hardware Status
+const uint8_t UBX_MON_HW3 = 0x37; //HW I/O pin information
+const uint8_t UBX_MON_HW = 0x09; //Hardware Status
+const uint8_t UBX_MON_IO = 0x02; //I/O Subsystem Status
+const uint8_t UBX_MON_MSGPP = 0x06; //Message Parse and Process Status
+const uint8_t UBX_MON_PATCH = 0x27; //Output information about installed patches
+const uint8_t UBX_MON_RF = 0x38; //RF information
+const uint8_t UBX_MON_RXBUF = 0x07; //Receiver Buffer Status
+const uint8_t UBX_MON_RXR = 0x21; //Receiver Status Information
+const uint8_t UBX_MON_TXBUF = 0x08; //Transmitter Buffer Status
+const uint8_t UBX_MON_VER = 0x04; //Receiver/Software Version
+
+//The following are used to configure the NAV UBX messages (navigation results messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 35-36)
+const uint8_t UBX_NAV_CLOCK = 0x22; //Clock Solution
+const uint8_t UBX_NAV_DOP = 0x04; //Dilution of precision
+const uint8_t UBX_NAV_EOE = 0x61; //End of Epoch
+const uint8_t UBX_NAV_GEOFENCE = 0x39; //Geofencing status
+const uint8_t UBX_NAV_HPPOSECEF = 0x13; //High Precision Position Solution in ECEF
+const uint8_t UBX_NAV_HPPOSLLH = 0x14; //High Precision Geodetic Position Solution
+const uint8_t UBX_NAV_ODO = 0x09; //Odometer Solution
+const uint8_t UBX_NAV_ORB = 0x34; //GNSS Orbit Database Info
+const uint8_t UBX_NAV_POSECEF = 0x01; //Position Solution in ECEF
+const uint8_t UBX_NAV_POSLLH = 0x02; //Geodetic Position Solution
+const uint8_t UBX_NAV_PVT = 0x07; //Navigation Position Velocity Time Solution
+const uint8_t UBX_NAV_RELPOSNED = 0x3C; //Relative Positioning Information in NED frame
+const uint8_t UBX_NAV_RESETODO = 0x10; //Reset odometer
+const uint8_t UBX_NAV_SAT = 0x35; //Satellite Information
+const uint8_t UBX_NAV_SIG = 0x43; //Signal Information
+const uint8_t UBX_NAV_STATUS = 0x03; //Receiver Navigation Status
+const uint8_t UBX_NAV_SVIN = 0x3B; //Survey-in data
+const uint8_t UBX_NAV_TIMEBDS = 0x24; //BDS Time Solution
+const uint8_t UBX_NAV_TIMEGAL = 0x25; //Galileo Time Solution
+const uint8_t UBX_NAV_TIMEGLO = 0x23; //GLO Time Solution
+const uint8_t UBX_NAV_TIMEGPS = 0x20; //GPS Time Solution
+const uint8_t UBX_NAV_TIMELS = 0x26; //Leap second event information
+const uint8_t UBX_NAV_TIMEUTC = 0x21; //UTC Time Solution
+const uint8_t UBX_NAV_VELECEF = 0x11; //Velocity Solution in ECEF
+const uint8_t UBX_NAV_VELNED = 0x12; //Velocity Solution in NED
+
+//The following are used to configure the RXM UBX messages (receiver manager messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 36)
+const uint8_t UBX_RXM_MEASX = 0x14; //Satellite Measurements for RRLP
+const uint8_t UBX_RXM_PMREQ = 0x41; //Requests a Power Management task (two differenent packet sizes)
+const uint8_t UBX_RXM_RAWX = 0x15; //Multi-GNSS Raw Measurement Data
+const uint8_t UBX_RXM_RLM = 0x59; //Galileo SAR Short-RLM report (two different packet sizes)
+const uint8_t UBX_RXM_RTCM = 0x32; //RTCM input status
+const uint8_t UBX_RXM_SFRBX = 0x13; //Boradcast Navigation Data Subframe
+
+//The following are used to configure the SEC UBX messages (security feature messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 36)
+const uint8_t UBX_SEC_UNIQID = 0x03; //Unique chip ID
+
+//The following are used to configure the TIM UBX messages (timing messages). Descriptions from UBX messages overview (ZED_F9P Interface Description Document page 36)
+const uint8_t UBX_TIM_TM2 = 0x03; //Time mark data
+const uint8_t UBX_TIM_TP = 0x01; //Time Pulse Timedata
+const uint8_t UBX_TIM_VRFY = 0x06; //Sourced Time Verification
+
+//The following are used to configure the UPD UBX messages (firmware update messages). Descriptions from UBX messages overview (ZED-F9P Interface Description Document page 36)
+const uint8_t UBX_UPD_SOS = 0x14; //Different based on message size (Poll Backup Fil Restore Status, Create Backup File in Flash, Clear Backup File in Flash, Backup File Creation Acknowledge, System Restored from Backup
+
+
 
 //The following are used to enable RTCM messages
 const uint8_t UBX_CFG_MSG = 0x01;
@@ -211,18 +347,18 @@ const uint8_t VAL_GROUP_I2C_SIZE = VAL_SIZE_8; //All fields in I2C group are cur
 
 const uint8_t VAL_ID_I2C_ADDRESS = 0x01;
 
-enum dynModel // Possible values for the dynamic platform model
+enum dynModel // Possible values for the dynamic platform model, which provide more accuract position output for the situation. Description extracted from ZED-F9P Integration Manual
 {
-	DYN_MODEL_PORTABLE = 0,
+	DYN_MODEL_PORTABLE = 0, //Applications with low acceleration, e.g. portable devices. Suitable for most situations.
 	// 1 is not defined
-	DYN_MODEL_STATIONARY = 2,
-	DYN_MODEL_PEDESTRIAN,
-	DYN_MODEL_AUTOMOTIVE,
-	DYN_MODEL_SEA,
-	DYN_MODEL_AIRBORNE1g,
-	DYN_MODEL_AIRBORNE2g,
-	DYN_MODEL_AIRBORNE4g,
-	DYN_MODEL_WRIST, // Not supported in protocol versions less than 18
+	DYN_MODEL_STATIONARY = 2, //Used in timing applications (antenna must be stationary) or other stationary applications. Velocity restricted to 0 m/s. Zero dynamics assumed.
+	DYN_MODEL_PEDESTRIAN, //Applications with low acceleration and speed, e.g. how a pedestrian would move. Low acceleration assumed.
+	DYN_MODEL_AUTOMOTIVE, //Used for applications with equivalent dynamics to those of a passenger car. Low vertical acceleration assumed
+	DYN_MODEL_SEA, //Recommended for applications at sea, with zero vertical velocity. Zero vertical velocity assumed. Sea level assumed.
+	DYN_MODEL_AIRBORNE1g, //Airborne <1g acceleration. Used for applications with a higher dynamic range and greater vertical acceleration than a passenger car. No 2D position fixes supported.
+	DYN_MODEL_AIRBORNE2g, //Airborne <2g acceleration. Recommended for typical airborne environments. No 2D position fixes supported.
+	DYN_MODEL_AIRBORNE4g, //Airborne <4g acceleration. Only recommended for extremely dynamic environments. No 2D position fixes supported.
+	DYN_MODEL_WRIST, // Not supported in protocol versions less than 18. Only recommended for wrist worn applications. Receiver will filter out arm motion.
 	DYN_MODEL_BIKE,  // Supported in protocol versions 19.2
 };
 

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -297,7 +297,6 @@ const uint8_t UBX_UPD_SOS = 0x14; //Poll Backup Fil Restore Status, Create Backu
 
 
 //The following are used to enable RTCM messages
-const uint8_t UBX_CFG_MSG = 0x01;
 const uint8_t UBX_RTCM_MSB = 0xF5;  //All RTCM enable commands have 0xF5 as MSB
 const uint8_t UBX_RTCM_1005 = 0x05; //Stationary RTK reference ARP
 const uint8_t UBX_RTCM_1074 = 0x4A; //GPS MSM4


### PR DESCRIPTION
Here are some small additions and expansions to the constants in the .h file, something I've been meaning to do for a while. Most of the descriptions are taken directly from the [ZED-F9P Interface Description](https://www.u-blox.com/sites/default/files/u-blox_ZED-F9P_InterfaceDescription_%28UBX-18010854%29.pdf) document or the [NEO-M9N Interface Description](https://www.u-blox.com/en/docs/UBX-18010854) document from [u-blox](https://www.u-blox.com/en).
I was unable to figure out how to insert links to highlighted sections of the code, so I have put line numbers from my code as a replacement. Hopefully they are sufficient.
Some constants may appear to have been deleted. They have been moved to their appropriate sections based on their contents (all UBX_CFG placed together, all UBX_CLASS placed together, etc.). If this format does not work, just let me know.

The first change (line 106-121) simply adds descriptions of the constants of the UBX Class IDs (UBX_CLASS). Useful to explain the abbreviations/short hand constants. Descriptions taken from [ZED-F9P Interface Description: 5.6 UBX Class IDs](https://www.u-blox.com/en/docs/UBX-18010854#%5B%7B%22num%22%3A115%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C498.9%2Cnull%5D).

The second change (line 123-153) adds descriptions of constants used for configuration (UBX_CFG). It also adds additional CFG messages that may not yet be implemented/needed. Listings and descriptions taken from [ZED-F9P Interface Description: 5.7 UBX Messages Overview](https://www.u-blox.com/en/docs/UBX-18010854#%5B%7B%22num%22%3A118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C739.84%2Cnull%5D) and [NEO-M9N Interface Description: 3.8 UBX messages overview](https://www.u-blox.com/en/docs/UBX-19035940#%5B%7B%22num%22%3A1332%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C59.527%2C573.177%2Cnull%5D). Some messages appear in one or the other or both, depending on it they are usable by said GPS module.

The third change (line 155-185) adds descriptions of NMEA messages and also adds additional NMEA messages not yet defined in this library. Descriptions taken from [ZED-F9P Interface Description: 4.1.8 Messages Overview](https://www.u-blox.com/en/docs/UBX-18010854#%5B%7B%22num%22%3A49%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C453.54%2Cnull%5D). If the extra messages are not necessary as new constants, they can easily be removed. This change also adds some constants that, in the future once implemented (future PR by me hopefully), will allow the library to change the NMEA Talker ID (GPS, GLONASS, BeiDou, etc.).

The fourth change (line 195-296) adds constants and descriptions for the rest of the UBX messages listed in the [ZED-F9P Interface Description: 5.7 UBX Messages Overview](https://www.u-blox.com/en/docs/UBX-18010854#%5B%7B%22num%22%3A118%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C739.84%2Cnull%5D) document. Most do not already exist in the library and may be excessive/never used by the user. But they may be useful for future development. Feel free to remove any ones you feel are excessive. I added these as I was already going through some of the existing UBX messages adding descriptions. Some of the UBX messages that appear to be deleted will most likely have been moved to their appropriate section in this block of new code.

The fifth and final change (line 356-367) adds descriptions for the dynamic platform model. Changing the dynamic platform model was a function I had planned to put into a PR, but it looks like someone beat me to it! Instead I will just add descriptions for the dynamic platform model options. Descriptions are taken from the [ZED-F9P Integration Manual 3.1.7: Navigation configuration](https://www.u-blox.com/en/docs/UBX-18010802#%5B%7B%22num%22%3A286%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C59.527%2C590.077%2Cnull%5D) document.


As always, feedback on my work is greatly appreciated. Hopefully this PR provides useful info and not too much excessive info. Also hope that this PR is better than my previous PR months ago, which was just a confusing mess of code from someone who had no idea how to contribute :)