### PR TITLE
add gnssFixOk and fix pDOP

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -512,6 +512,7 @@ void SFE_UBLOX_GPS::processUBXpacket(ubxPacket *msg)
 
       fixType = extractByte(20 - startingSpot);
       carrierSolution = extractByte(21 - startingSpot) >> 6; //Get 6th&7th bits of this byte
+      gnssFixOK = extractByte(21 - startingSpot) & 0x01;
       SIV = extractByte(23 - startingSpot);
       longitude = extractLong(24 - startingSpot);
       latitude = extractLong(28 - startingSpot);
@@ -519,7 +520,7 @@ void SFE_UBLOX_GPS::processUBXpacket(ubxPacket *msg)
       altitudeMSL = extractLong(36 - startingSpot);
       groundSpeed = extractLong(60 - startingSpot);
       headingOfMotion = extractLong(64 - startingSpot);
-      pDOP = extractLong(76 - startingSpot);
+      pDOP = extractInt(76 - startingSpot);
 
       //Mark all datums as fresh (not read before)
       moduleQueried.gpsYear = true;

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -336,6 +336,7 @@ public:
 	uint8_t SIV;			 //Number of satellites used in position solution
 	uint8_t fixType;		 //Tells us when we have a solution aka lock
 	uint8_t carrierSolution; //Tells us when we have an RTK float/fixed solution
+	bool    gnssFixOK;       // valid fix (i.e within DOP & accuracy masks)
 	int32_t groundSpeed;	 //mm/s
 	int32_t headingOfMotion; //degrees * 10^-5
 	uint16_t pDOP;			 //Positional dilution of precision


### PR DESCRIPTION
This commit adds gnssFixOk to the global vars.
It also fixes an incorrectly declared data type for pDOP.