### PR TITLE
Corrected the layer in getVal8

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -1347,8 +1347,19 @@ uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
   for (uint8_t x = 0; x < packetCfg.len; x++)
     packetCfg.payload[x] = 0;
 
+  //VALGET uses different memory layer definitions to VALSET
+  //because it can only return the value for one layer.
+  //So we need to fiddle the layer here.
+  //And just to complicate things further, the ZED-F9P only responds
+  //correctly to layer 0 (RAM) and layer 7 (Default)!
+  uint8_t getLayer = 7; // 7 is the "Default Layer"
+  if ((layer & VAL_LAYER_RAM) == VAL_LAYER_RAM) // Did the user request the RAM layer?
+  {
+    getLayer = 0; // Layer 0 is RAM
+  }
+
   payloadCfg[0] = 0;     //Message Version - set to 0
-  payloadCfg[1] = layer; //By default we ask for the BBR layer
+  payloadCfg[1] = getLayer; //Layer
 
   //Load key into outgoing payload
   payloadCfg[4] = key >> 8 * 0; //Key LSB


### PR DESCRIPTION
VALGET uses different layer definitions to VALSET...
So we need to replace the layer value when calling getVal8.
The layers should be:
![image](https://user-images.githubusercontent.com/5690545/79398686-25ca3280-7f79-11ea-842d-cc4bcea4e03e.png)
but just to complicate things further, the ZED-F9P only responds to "0" (RAM) and "7" (Default)!
