### PR TITLE
Better packet validity checking

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -104,6 +104,14 @@ typedef enum
 	SFE_UBLOX_STATUS_I2C_COMM_FAILURE,
 } sfe_ublox_status_e;
 
+// ubxPacket validity
+typedef enum
+{
+  SFE_UBLOX_PACKET_VALIDITY_NOT_VALID,
+  SFE_UBLOX_PACKET_VALIDITY_VALID,
+  SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED
+} sfe_ublox_packet_validity_e;
+
 //Registers
 const uint8_t UBX_SYNCH_1 = 0xB5;
 const uint8_t UBX_SYNCH_2 = 0x62;
@@ -400,7 +408,7 @@ typedef struct
 	uint8_t *payload;
 	uint8_t checksumA; //Given to us from module. Checked against the rolling calculated A/B checksums.
 	uint8_t checksumB;
-	boolean valid; //Goes true when both checksums pass
+	sfe_ublox_packet_validity_e valid; //Goes from NOT_DEFINED to VALID or NOT_VALID when checksum is checked
 } ubxPacket;
 
 // Struct to hold the results returned by getGeofenceState (returned by UBX-NAV-GEOFENCE)
@@ -702,8 +710,8 @@ private:
 	uint8_t payloadCfg[MAX_PAYLOAD_SIZE];
 
 	//Init the packet structures and init them with pointers to the payloadAck and payloadCfg arrays
-	ubxPacket packetAck = {0, 0, 0, 0, 0, payloadAck, 0, 0, false};
-	ubxPacket packetCfg = {0, 0, 0, 0, 0, payloadCfg, 0, 0, false};
+	ubxPacket packetAck = {0, 0, 0, 0, 0, payloadAck, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
+	ubxPacket packetCfg = {0, 0, 0, 0, 0, payloadCfg, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
 
 	//Limit checking of new data to every X ms
 	//If we are expecting an update every X Hz then we should check every half that amount of time


### PR DESCRIPTION
This merge is a big one!
It addresses Issue #85 where the fault was manifesting as CRC failures when using Serial.
The underlying problem was actually caused by the slow arrival rate of serial bytes.
It was possible for a received packet to appear valid (with the expected class and ID) _before_ the end of the message had actually been received. The CRC did of course fail as not all of the bytes had been received.
This would not have been seen on I2C / Qwiic because there the whole message appears in the module's buffer at the same instant and the complete message can be read all in one go.
The solution involves defining three states for the packet validity: VALID (the whole message has been received and the checksum is OK); NOT_VALID (the whole message has been received and the checksum has actually failed - which should be extremely rare!); NOT_DEFINED (we have not yet reached the end of the message and cannot yet check the checksum).
This has been checked using:
- SoftwareSerial: RedBoard ATmega328P + NEO_M8T
- I2C / Qwiic: RedBoard ATmega328P + NEO_M8T
- Serial1: Artemis Thing Plus + NEO_M8T
- I2C / Qwiic: Artemis Thing Plus + NEO_M8T
- I2C / Qwiic: RedBoard ATmega328P + ZED_F9P

The standard examples have been tested successfully on all sets of hardware.
Confidence is high!
Enjoy!
_**Paul**_