### PR TITLE
Removed the reference to the SAM-M8Q

### DIFF
--- a/examples/ZED-F9P/Example8_GetHighPrecisionPositionAndAccuracy/Example8_GetHighPrecisionPositionAndAccuracy.ino
+++ b/examples/ZED-F9P/Example8_GetHighPrecisionPositionAndAccuracy/Example8_GetHighPrecisionPositionAndAccuracy.ino
@@ -14,7 +14,6 @@
   Buy a board from SparkFun!
   ZED-F9P RTK2: https://www.sparkfun.com/products/15136
   NEO-M8P RTK: https://www.sparkfun.com/products/15005
-  SAM-M8Q: https://www.sparkfun.com/products/15106
 
   Hardware Connections:
   Plug a Qwiic cable into the GPS and a BlackBoard


### PR DESCRIPTION
Removed the reference to the SAM-M8Q from ZED-F9P\Example8_GetHighPrecisionPositionAndAccuracy. It doesn't offer HP functionality and customers might be confused into thinking that it does...