### PR TITLE
Commits fro V1.8.1 : corrected checkUblox

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Ublox Arduino Library
-version=1.8.0
+version=1.8.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for I2C and Serial Communication with Ublox modules

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -585,7 +585,9 @@ void SFE_UBLOX_GPS::process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t re
             _debugSerial->print(F("process: ACK received with .len != 2: Class: 0x"));
             _debugSerial->print(packetBuf.payload[0], HEX);
             _debugSerial->print(F(" ID: 0x"));
-            _debugSerial->println(packetBuf.payload[1], HEX);
+            _debugSerial->print(packetBuf.payload[1], HEX);
+            _debugSerial->print(F(" len: "));
+            _debugSerial->println(packetBuf.len);
           }
         }
       }
@@ -780,7 +782,11 @@ void SFE_UBLOX_GPS::processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t
         }
       }
 
-      processUBXpacket(incomingUBX); //We've got a valid packet, now do something with it
+      //We've got a valid packet, now do something with it but only if ignoreThisPayload is false
+      if (ignoreThisPayload == false)
+      {
+        processUBXpacket(incomingUBX);
+      }
     }
     else  // Checksum failure
     {
@@ -1217,12 +1223,21 @@ void SFE_UBLOX_GPS::printPacket(ubxPacket *packet)
     _debugSerial->print(F(" Len: 0x"));
     _debugSerial->print(packet->len, HEX);
 
-    _debugSerial->print(F(" Payload:"));
-
-    for (int x = 0; x < packet->len; x++)
+    // Only print the payload is ignoreThisPayload is false otherwise
+    // we could be printing gibberish from beyond the end of packetBuf
+    if (ignoreThisPayload == false)
     {
-      _debugSerial->print(F(" "));
-      _debugSerial->print(packet->payload[x], HEX);
+      _debugSerial->print(F(" Payload:"));
+
+      for (int x = 0; x < packet->len; x++)
+      {
+        _debugSerial->print(F(" "));
+        _debugSerial->print(packet->payload[x], HEX);
+      }
+    }
+    else
+    {
+      _debugSerial->print(F(" Payload: IGNORED"));
     }
     _debugSerial->println();
   }

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -266,7 +266,13 @@ void SFE_UBLOX_GPS::setNMEAOutputPort(Stream &nmeaOutputPort)
 }
 
 //Called regularly to check for available bytes on the user' specified port
-boolean SFE_UBLOX_GPS::checkUblox(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID)
+boolean SFE_UBLOX_GPS::checkUblox(uint8_t requestedClass, uint8_t requestedID)
+{
+  return checkUbloxInternal(&packetCfg, requestedClass, requestedID);
+}
+
+//Called regularly to check for available bytes on the user' specified port
+boolean SFE_UBLOX_GPS::checkUbloxInternal(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID)
 {
   if (commType == COMM_TYPE_I2C)
     return (checkUbloxI2C(incomingUBX, requestedClass, requestedID));
@@ -1289,7 +1295,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForACKResponse(ubxPacket *outgoingUBX, uin
   unsigned long startTime = millis();
   while (millis() - startTime < maxTime)
   {
-    if (checkUblox(outgoingUBX, requestedClass, requestedID) == true) //See if new data is available. Process bytes as they come in.
+    if (checkUbloxInternal(outgoingUBX, requestedClass, requestedID) == true) //See if new data is available. Process bytes as they come in.
     {
       // If both the outgoingUBX->classAndIDmatch and packetAck.classAndIDmatch are VALID
       // and outgoingUBX->valid is _still_ VALID and the class and ID _still_ match
@@ -1425,7 +1431,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForACKResponse(ubxPacket *outgoingUBX, uin
         }
       }
 
-    } //checkUblox == true
+    } //checkUbloxInternal == true
 
     delayMicroseconds(500);
   } //while (millis() - startTime < maxTime)
@@ -1476,7 +1482,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::waitForNoACKResponse(ubxPacket *outgoingUBX, u
   unsigned long startTime = millis();
   while (millis() - startTime < maxTime)
   {
-    if (checkUblox(outgoingUBX, requestedClass, requestedID) == true) //See if new data is available. Process bytes as they come in.
+    if (checkUbloxInternal(outgoingUBX, requestedClass, requestedID) == true) //See if new data is available. Process bytes as they come in.
     {
 
       // If outgoingUBX->classAndIDmatch is VALID
@@ -2718,7 +2724,7 @@ boolean SFE_UBLOX_GPS::getPVT(uint16_t maxWait)
     {
       _debugSerial->println(F("getPVT: Autoreporting"));
     }
-    checkUblox(&packetCfg, UBX_CLASS_NAV, UBX_NAV_PVT);
+    checkUbloxInternal(&packetCfg, UBX_CLASS_NAV, UBX_NAV_PVT);
     return moduleQueried.all;
   }
   else if (autoPVT && !autoPVTImplicitUpdate)

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -462,12 +462,15 @@ public:
 	//maxWait is only used for Serial
 	boolean isConnected(uint16_t maxWait = 1100);
 
-	boolean checkUblox(ubxPacket *incomingUBX, uint8_t requestedClass = 255, uint8_t requestedID = 255);		//Checks module with user selected commType
-	boolean checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedClass = 255, uint8_t requestedID = 255);	//Method for I2C polling of data, passing any new bytes to process()
-	boolean checkUbloxSerial(ubxPacket *incomingUBX, uint8_t requestedClass = 255, uint8_t requestedID = 255); //Method for serial polling of data, passing any new bytes to process()
+	//Changed in V1.8.1: provides backward compatibility for the examples that call checkUblox directly
+	//Will default to using packetCfg to look for explicit autoPVT packets so they get processed correctly by processUBX
+	boolean checkUblox(uint8_t requestedClass = UBX_CLASS_NAV, uint8_t requestedID = UBX_NAV_PVT);		//Checks module with user selected commType
 
-	void process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass = 255, uint8_t requestedID = 255); //Processes NMEA and UBX binary sentences one byte at a time
-	void processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass = 255, uint8_t requestedID = 255); //Given a character, file it away into the uxb packet structure
+	boolean checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID);	//Method for I2C polling of data, passing any new bytes to process()
+	boolean checkUbloxSerial(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Method for serial polling of data, passing any new bytes to process()
+
+	void process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Processes NMEA and UBX binary sentences one byte at a time
+	void processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Given a character, file it away into the uxb packet structure
 	void processRTCMframe(uint8_t incoming);				  //Monitor the incoming bytes for start and length bytes
 	void processRTCM(uint8_t incoming) __attribute__((weak));  //Given rtcm byte, do something with it. User can overwrite if desired to pipe bytes to radio, internet, etc.
 
@@ -723,6 +726,7 @@ private:
 	} commType = COMM_TYPE_I2C; //Controls which port we look to for incoming bytes
 
 	//Functions
+	boolean checkUbloxInternal(ubxPacket *incomingUBX, uint8_t requestedClass = 255, uint8_t requestedID = 255);		//Checks module with user selected commType
 	uint32_t extractLong(uint8_t spotToStart); //Combine four bytes from payload into long
 	uint16_t extractInt(uint8_t spotToStart);  //Combine two bytes from payload into int
 	uint8_t extractByte(uint8_t spotToStart);  //Get byte from payload


### PR DESCRIPTION
These commits correct issue #100 :
checkUblox now calls checkUbloxInternal and will default to checking for NAV PVT using packetCfg for the examples that call checkUblox directly.
