### PR TITLE
add func getModuleInfo and example

### DIFF
--- a/examples/Example8_GetProtocolVersion/Example8_1_GetModuleInfo.ino
+++ b/examples/Example8_GetProtocolVersion/Example8_1_GetModuleInfo.ino
@@ -1,0 +1,70 @@
+/*
+  Reading the Information texts of a Ublox module
+  By: mayopan
+  https://github.com/mayopan
+  Date: May 4th, 2020
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  This example shows how to get Ublox module information in text.
+  It's for UART connection to GPS.
+  If you want to connect GPS through i2c, include Wire.h
+
+
+  Hardware Connections:
+  Plug a Qwiic cable into the GPS and a BlackBoard
+  If you don't have a platform with a Qwiic connection use the SparkFun Qwiic Breadboard Jumper (https://www.sparkfun.com/products/14425)
+  Open the serial monitor at 115200 baud to see the output
+*/
+
+//#include <Wire.h> //Needed for I2C to GPS
+
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+
+SFE_UBLOX_GPS myGPS;
+
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial)
+    ; //Wait for user to open terminal
+  Serial.println("SparkFun Ublox Example");
+
+  Serial2.begin(115200);
+  delay(50);
+  if (myGPS.begin(Serial2) == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("115200 baud connection is failed. Trying at 9600 baud."));
+    Serial2.begin(9600);
+    delay(50);
+  }
+
+    if (myGPS.begin(Serial2) == false) //Connect to the Ublox module using Wire port
+    {
+      Serial.println(F("Ublox GPS not detected. Please check wiring. Freezing."));
+      while (1)
+        ;
+    }
+
+    myGPS.getModuleInfo();
+    Serial.println("Module Info : ");
+    Serial.print("Soft version: ");
+    Serial.println(myGPS.minfo.swVersion);
+    Serial.print("Hard version: ");
+    Serial.println(myGPS.minfo.hwVersion);
+    Serial.println("Extensions:");
+    for (int i = 0; i < myGPS.minfo.extensionNo; i++)
+    {
+      Serial.print("  ");
+      Serial.println(myGPS.minfo.extension[i]);
+    }
+    Serial.println();
+    Serial.println("Done!");
+  }
+
+void loop()
+{
+  //Do nothing
+}

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -609,6 +609,7 @@ public:
 	uint8_t getProtocolVersionHigh(uint16_t maxWait = 500); //Returns the PROTVER XX.00 from UBX-MON-VER register
 	uint8_t getProtocolVersionLow(uint16_t maxWait = 500);  //Returns the PROTVER 00.XX from UBX-MON-VER register
 	boolean getProtocolVersion(uint16_t maxWait = 500);		//Queries module, loads low/high bytes
+	boolean getModuleInfo(uint16_t maxWait = 500);			//Queries module, texts
 
 	boolean getRELPOSNED(uint16_t maxWait = 1100); //Get Relative Positioning Information of the NED frame
 
@@ -677,6 +678,15 @@ public:
 		bool refPosMiss;
 		bool refObsMiss;
 	} relPosInfo;
+
+	//Module infomation
+	struct minfoStructure
+	{
+		char swVersion[30];
+		char hwVersion[10];
+		uint8_t extensionNo;
+		char extension[10][30];
+	} minfo;
 
 	//The major datums we want to globally store
 	uint16_t gpsYear;


### PR DESCRIPTION
There is already a useful function "getProtocolVersion".
But it shows just protocol version number.
So I made a new function getModuleInfo.
It pulls not only versions but also extension information as strings like below.
[I made this before](https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library/issues/73#issuecomment-587057558) to the branch from the library ver 1.7.0, but it has unstable communication around sendCommand and ACK NACK.
But it's fixed in the latest version(later than 1.8.0).
Thanks sparkfun and communities.

Module Info : 
Soft version: EXT CORE 3.01 (107900)
Hard version: 00080000
Extensions:
  ROM BASE 3.01 (107888)
  FWVER=SPG 3.01
  PROTVER=18.00
  MOD=NEO-M8N-0
  FIS=0xEF4015 (100111)
  GPS;GLO;GAL;BDS
  SBAS;IMES;QZSS