### PR TITLE
implemented Power On/Off (UBX-RXM-PMREQ)

### DIFF
--- a/examples/Example22_PowerOff/Example22_PowerOff.ino
+++ b/examples/Example22_PowerOff/Example22_PowerOff.ino
@@ -1,0 +1,85 @@
+/*
+  Powering off a ublox GPS module
+  By: bjorn
+  unsurv.org
+  Date: July 20th, 2020
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  This example shows you how to turn off the ublox module to lower the power consumption.
+  There are two functions: one just specifies a duration in milliseconds the other also specifies a pin on the GPS device to wake it up with.
+  By driving a voltage from LOW to HIGH or HIGH to LOW on the chosen module pin you wake the device back up.
+  Note: Doing so on the INT0 pin when using the regular powerOff(durationInMs) function will wake the device anyway. (tested on SAM-M8Q)
+  Note: While powered off, you should not query the device for data or it might wake up. This can be used to wake the device but is not recommended.
+        Works best when also putting your microcontroller to sleep.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  ZED-F9P RTK2: https://www.sparkfun.com/products/15136
+  NEO-M8P RTK: https://www.sparkfun.com/products/15005
+  SAM-M8Q: https://www.sparkfun.com/products/15106
+
+  Hardware Connections:
+  Plug a Qwiic cable into the GPS and a BlackBoard.
+  To force the device to wake up you need to connect to a pin (for example INT0) seperately on the module.
+  If you don't have a platform with a Qwiic connection use the SparkFun Qwiic Breadboard Jumper (https://www.sparkfun.com/products/14425)
+  Open the serial monitor at 115200 baud to see the output
+*/
+
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+SFE_UBLOX_GPS myGPS;
+
+// define a digital pin capable of driving HIGH and LOW
+#define WAKEUP_PIN 5
+
+// interrupt pin mapping
+#define GPS_RX     0
+#define GPS_INT0   1
+#define GPS_INT1   2
+#define GPS_SPI_CS 3
+
+
+void wakeUp() {
+
+  Serial.print("-- waking up module via pin " + String(WAKEUP_PIN));
+  Serial.println(" on your microcontroller --");
+
+  digitalWrite(WAKEUP_PIN, LOW);
+  delay(1000);
+  digitalWrite(WAKEUP_PIN, HIGH);
+  delay(1000);
+  digitalWrite(WAKEUP_PIN, LOW);
+}
+
+
+void setup() {
+
+  pinMode(WAKEUP_PIN, OUTPUT);
+
+  Serial.begin(115200);
+  while (!Serial); //Wait for user to open terminal
+  Serial.println("SparkFun Ublox Example");
+
+  Wire.begin();
+
+  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  {
+    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    while (1);
+  }
+
+  // Powering off for 20s, you should see the power consumption drop.
+  Serial.println("-- Powering off module for 20s --");
+
+  myGPS.powerOff(20000);
+  // myGPS.powerOffWithInterrupt(20000, GPS_INT0);
+
+  delay(10000);
+
+  // After 10 seconds wake the device via the specified pin on your microcontroller and module.
+  wakeUp();
+}
+
+void loop() {
+  //Do nothing
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -139,6 +139,8 @@ setDynamicModel	KEYWORD2
 getDynamicModel	KEYWORD2
 powerSaveMode	KEYWORD2
 getPowerSaveMode	KEYWORD2
+powerOff KEYWORD2
+powerOffWithInterrupt KEYWORD2
 
 configureMessage	KEYWORD2
 enableMessage	KEYWORD2

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -2570,7 +2570,9 @@ uint8_t SFE_UBLOX_GPS::getPowerSaveMode(uint16_t maxWait)
 }
 
 // Powers off the GPS device for a given duration to reduce power consumption.
-// WARNING: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
+// NOTE: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
+// returns true if command has not failed
+// returns false if command has not been acknowledged or maxWait = 0
 boolean SFE_UBLOX_GPS::powerOff(uint32_t durationInMs,  uint16_t maxWait)
 {
   // use durationInMs = 0 for infinite duration
@@ -2594,14 +2596,24 @@ boolean SFE_UBLOX_GPS::powerOff(uint32_t durationInMs,  uint16_t maxWait)
   payloadCfg[2] = (durationInMs >> (8*2)) & 0xff;
   payloadCfg[3] = (durationInMs >> (8*3)) & 0xff;
 
-  // check for "not acknowledged" command
-  return (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_COMMAND_NACK);
+  if (maxWait != 0)
+  {
+    // check for "not acknowledged" command
+    return (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_COMMAND_NACK);
+  }
+  else
+  {
+    sendCommand(&packetCfg, maxWait);
+    return false; // can't tell if command not acknowledged if maxWait = 0
+  }
 }
 
 // Powers off the GPS device for a given duration to reduce power consumption.
 // While powered off it can be woken up by creating a falling or rising voltage edge on the specified pin.
-// WARNING: The GPS seems to detect small voltage edges on the interrupt pin. Works best when Microcontroller is in deepsleep.
-// WARNING: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
+// NOTE: The GPS seems to detect small voltage edges on the interrupt pin. Works best when Microcontroller is in deepsleep.
+// NOTE: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
+// returns true if command has not failed
+// returns false if command has not been acknowledged or maxWait = 0
 boolean SFE_UBLOX_GPS::powerOffWithInterrupt(uint32_t durationInMs, uint8_t wakeupPin, boolean forceWhileUsb, uint16_t maxWait)
 {
   // use durationInMs = 0 for infinite duration
@@ -2673,8 +2685,16 @@ boolean SFE_UBLOX_GPS::powerOffWithInterrupt(uint32_t durationInMs, uint8_t wake
 
   payloadCfg[15] = terminatingByte;
 
-  // check for "not acknowledged" command
-  return (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_COMMAND_NACK);
+  if (maxWait != 0)
+  {
+    // check for "not acknowledged" command
+    return (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_COMMAND_NACK);
+  }
+  else
+  {
+    sendCommand(&packetCfg, maxWait);
+    return false; // can't tell if command not acknowledged if maxWait = 0
+  }
 }
 
 //Change the dynamic platform model using UBX-CFG-NAV5

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -2571,8 +2571,8 @@ uint8_t SFE_UBLOX_GPS::getPowerSaveMode(uint16_t maxWait)
 
 // Powers off the GPS device for a given duration to reduce power consumption.
 // NOTE: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
-// returns true if command has not failed
-// returns false if command has not been acknowledged or maxWait = 0
+// Returns true if command has not been not acknowledged.
+// Returns false if command has not been acknowledged or maxWait = 0.
 boolean SFE_UBLOX_GPS::powerOff(uint32_t durationInMs,  uint16_t maxWait)
 {
   // use durationInMs = 0 for infinite duration
@@ -2610,10 +2610,10 @@ boolean SFE_UBLOX_GPS::powerOff(uint32_t durationInMs,  uint16_t maxWait)
 
 // Powers off the GPS device for a given duration to reduce power consumption.
 // While powered off it can be woken up by creating a falling or rising voltage edge on the specified pin.
-// NOTE: The GPS seems to detect small voltage edges on the interrupt pin. Works best when Microcontroller is in deepsleep.
+// NOTE: The GPS seems to be sensitve to signals on the pins while powered off. Works best when Microcontroller is in deepsleep.
 // NOTE: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
-// returns true if command has not failed
-// returns false if command has not been acknowledged or maxWait = 0
+// Returns true if command has not been not acknowledged.
+// Returns false if command has not been acknowledged or maxWait = 0.
 boolean SFE_UBLOX_GPS::powerOffWithInterrupt(uint32_t durationInMs, uint8_t wakeupPin, boolean forceWhileUsb, uint16_t maxWait)
 {
   // use durationInMs = 0 for infinite duration

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -2600,6 +2600,7 @@ boolean SFE_UBLOX_GPS::powerOff(uint32_t durationInMs,  uint16_t maxWait)
 
 // Powers off the GPS device for a given duration to reduce power consumption.
 // While powered off it can be woken up by creating a falling or rising voltage edge on the specified pin.
+// WARNING: The GPS seems to detect small voltage edges on the interrupt pin. Works best when Microcontroller is in deepsleep.
 // WARNING: Querying the device before the duration is complete, for example by "getLatitude()" will wake it up!
 boolean SFE_UBLOX_GPS::powerOffWithInterrupt(uint32_t durationInMs, uint8_t wakeupPin, boolean forceWhileUsb, uint16_t maxWait)
 {

--- a/src/SparkFun_Ublox_Arduino_Library.h
+++ b/src/SparkFun_Ublox_Arduino_Library.h
@@ -641,6 +641,8 @@ public:
 
 	boolean powerSaveMode(bool power_save = true, uint16_t maxWait = 1100);
 	uint8_t getPowerSaveMode(uint16_t maxWait = 1100); // Returns 255 if the sendCommand fails
+	boolean powerOff(uint32_t durationInMs, uint16_t maxWait = 1100);
+	boolean powerOffWithInterrupt(uint32_t durationInMs, uint8_t wakeupPin = 1, boolean forceWhileUsb = true, uint16_t maxWait = 1100);
 
 	//Change the dynamic platform model using UBX-CFG-NAV5
 	boolean setDynamicModel(dynModel newDynamicModel = DYN_MODEL_PORTABLE, uint16_t maxWait = 1100);


### PR DESCRIPTION
Hey, this is my first pull request hope I did everything right.

I added the ability to power off the GPS device. I worked with [this](https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29.pdf) protocol specification. 

My initial testing with a Sparkfun SAM-M8Q board and a not that reliable USB power meter showed a current drop of 30mA. Together with the ESP32 deepsleep the reading was at 0.00A This should be validated with a better test setup though. That's also why I haven't added an additional example yet.

Furthermore can you guys have a look at the return statements. I guess I'm comparing to the wrong value or the GPS just doesn't acknowledge a power off command.

I tested with EXINT0 and UARTRX as interrupt pins and it behaved as expected.
As described [here](https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29.pdf#%5B%7B%22num%22%3A235%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C657.64%2Cnull%5D) activity on some pins wake up the device. Although the I2C pins are not named there, when querying "getLatitude()" or similar extensively via a I2C connection the device seems to wake up too. Can you reproduce this? 

Some further testing revealed that when using powerOffWithInterrupt() small voltage edges on presumably the interrupt pin are detected (can't check) and wake the device. I got a good result again when also putting my ESP32 in deepsleep at the same time.

Best

My test code is as folllows and uses an ESP32 WROOM connected via I2C and the INT pin:
GitHub code formatting doesn't like my code... sry :o

[simple_ublox_pwr_off.txt](https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library/files/4942681/simple_ublox_pwr_off.txt)


