### PR TITLE
Payload buffer overrun fix

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -924,14 +924,14 @@ void SFE_UBLOX_GPS::processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t
     uint16_t startingSpot = incomingUBX->startingSpot;
     if (incomingUBX->cls == UBX_CLASS_NAV && incomingUBX->id == UBX_NAV_PVT)
       startingSpot = 0;
-    //Begin recording if counter goes past startingSpot
-    if ((incomingUBX->counter - 4) >= startingSpot)
+    // Check if this is payload data which should be ignored
+    if (ignoreThisPayload == false)
     {
-      //Check to see if we have room for this byte
-      if (((incomingUBX->counter - 4) - startingSpot) < MAX_PAYLOAD_SIZE) //If counter = 208, starting spot = 200, we're good to record.
+      //Begin recording if counter goes past startingSpot
+      if ((incomingUBX->counter - 4) >= startingSpot)
       {
-        // Check if this is payload data which should be ignored
-        if (ignoreThisPayload == false)
+        //Check to see if we have room for this byte
+        if (((incomingUBX->counter - 4) - startingSpot) < MAX_PAYLOAD_SIZE) //If counter = 208, starting spot = 200, we're good to record.
         {
           incomingUBX->payload[incomingUBX->counter - 4 - startingSpot] = incoming; //Store this byte into payload array
         }


### PR DESCRIPTION
There is a latent buffer overrun issue in SFE_UBLOX_GPS::processUBX()

**Bug**
in processUBX(), when writing to incomingUBX->payload[], the index was only checked against MAX_PAYLOAD_SIZE (256). But incomingUBX can also be packetAck or packetBuf which have much smaller buffers (2). In case of certain corrupted input, a buffer overrun is not ruled out and happened in our setup. This code change fixed the problem for us and I believe there should be no side effects.

**Occurance**
The bug will only show up if the input stream from the GPS is corrupted. Here is a real example of a such corrupted stream. 

I believe that the library should be able to handle corrupted streams and should never allow a buffer to overflow. The pull request rules out a buffer overrun.

**Real example of corrupted stream**
_as processed by process(), the decimal number is the value of ubxFrameCounter  at the beginning of process()_
[025] 00
[026] ae
[027] 72

[028] b5
[001] 62
[002] 05	<--- UBX-ACK class 0x05  (requestedClass differs and is 0x06)
[003] 01	<--- UBX-ACK-ACK id  0x01 (requestedId differs and is 0x00)
		<--- Unexpected end of packet  (something is missing here)
[004] 82	<--- interpreted as length, is probably last checksum byte of a mostly lost packet	
[005] b5	<--- begin of next packet, still being interpreted as length (b5 82 -> len=46466)
[006] 62
[007] 05
[008] 01