### PR TITLE
Adding support for u-blox generation 7 NAV-PVT will allow current exa…

### DIFF
--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -962,7 +962,7 @@ void SFE_UBLOX_GPS::processUBXpacket(ubxPacket *msg)
   switch (msg->cls)
   {
   case UBX_CLASS_NAV:
-    if (msg->id == UBX_NAV_PVT && msg->len == 92)
+    if (msg->id == UBX_NAV_PVT && (msg->len == 92 || (msg->len == 84 && getProtocolVersionHigh(defaultMaxWait) == 14)))
     {
       //Parse various byte fields into global vars
       constexpr int startingSpot = 0; //fixed value used in processUBX


### PR DESCRIPTION
…mples using NAV-PVT to be backwards compatable.

Protocol >= 15 (Gen 8 and beyond) has a message length of 92
Protocol = 14 (Gen 7) has a message length of 84
Protocol < 14 (Gen 6 and eariler) does not support NAV-PVT

Fields added in protocol 15 (headVeh, magDec, magAcc) are not being parsed in current version of the library.