### PR TITLE
Update library helper links and correct all instances of "Ublox"

### DIFF
--- a/examples/Dead Reckoning/Example1_calibrateSensor/Example1_calibrateSensor.ino
+++ b/examples/Dead Reckoning/Example1_calibrateSensor/Example1_calibrateSensor.ino
@@ -32,20 +32,20 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println(F("SparkFun Ublox Example"));
+  Serial.println(F("SparkFun u-blox Example"));
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Dead Reckoning/Example1_calibrateSensor/Example1_calibrateSensor.ino
+++ b/examples/Dead Reckoning/Example1_calibrateSensor/Example1_calibrateSensor.ino
@@ -32,7 +32,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Dead Reckoning/Example2_getIMUData/Example2_getIMUData.ino
+++ b/examples/Dead Reckoning/Example2_getIMUData/Example2_getIMUData.ino
@@ -24,20 +24,20 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println(F("SparkFun Ublox Example"));
+  Serial.println(F("SparkFun u-blox Example"));
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Dead Reckoning/Example2_getIMUData/Example2_getIMUData.ino
+++ b/examples/Dead Reckoning/Example2_getIMUData/Example2_getIMUData.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Dead Reckoning/Example3_getSensorStatus/Example3_getSensorStatus.ino
+++ b/examples/Dead Reckoning/Example3_getSensorStatus/Example3_getSensorStatus.ino
@@ -28,20 +28,20 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println(F("SparkFun Ublox Example"));
+  Serial.println(F("SparkFun u-blox Example"));
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Dead Reckoning/Example3_getSensorStatus/Example3_getSensorStatus.ino
+++ b/examples/Dead Reckoning/Example3_getSensorStatus/Example3_getSensorStatus.ino
@@ -28,7 +28,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Dead Reckoning/Example4_vehicleDynamics/Example4_vehicleDynamics.ino
+++ b/examples/Dead Reckoning/Example4_vehicleDynamics/Example4_vehicleDynamics.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Dead Reckoning/Example4_vehicleDynamics/Example4_vehicleDynamics.ino
+++ b/examples/Dead Reckoning/Example4_vehicleDynamics/Example4_vehicleDynamics.ino
@@ -26,20 +26,20 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println(F("SparkFun Ublox Example"));
+  Serial.println(F("SparkFun u-blox Example"));
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Dead Reckoning/Example5_getHNRData/Example5_getHNRData.ino
+++ b/examples/Dead Reckoning/Example5_getHNRData/Example5_getHNRData.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
@@ -42,7 +42,7 @@ void setup()
 
   //myGPS.enableDebugging(); // Uncomment this line to enable debug messages on Serial
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
     Serial.println(F("Warning! u-blox GPS did not begin correctly."));
     Serial.println(F("(This may be because the I2C port is busy with HNR messages.)"));

--- a/examples/Dead Reckoning/Example5_getHNRData/Example5_getHNRData.ino
+++ b/examples/Dead Reckoning/Example5_getHNRData/Example5_getHNRData.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Dead Reckoning/Example6_getAutoHNRData/Example6_getAutoHNRData.ino
+++ b/examples/Dead Reckoning/Example6_getAutoHNRData/Example6_getAutoHNRData.ino
@@ -28,7 +28,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 boolean usingAutoHNRAtt = false;
@@ -45,7 +45,7 @@ void setup()
 
   //myGPS.enableDebugging(); // Uncomment this line to enable debug messages on Serial
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
     Serial.println(F("Warning! u-blox GPS did not begin correctly."));
     Serial.println(F("(This may be because the I2C port is busy with HNR messages.)"));

--- a/examples/Dead Reckoning/Example6_getAutoHNRData/Example6_getAutoHNRData.ino
+++ b/examples/Dead Reckoning/Example6_getAutoHNRData/Example6_getAutoHNRData.ino
@@ -28,7 +28,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 boolean usingAutoHNRAtt = false;

--- a/examples/Example10_AltitudeMSL/Example10_AltitudeMSL.ino
+++ b/examples/Example10_AltitudeMSL/Example10_AltitudeMSL.ino
@@ -30,7 +30,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Tracks the passing of 2000ms (2 seconds)

--- a/examples/Example10_AltitudeMSL/Example10_AltitudeMSL.ino
+++ b/examples/Example10_AltitudeMSL/Example10_AltitudeMSL.ino
@@ -6,7 +6,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for its lat/long/altitude. 
+  This example shows how to query a u-blox module for its lat/long/altitude. 
 
   getAltitude() reports mm above ellipsode model of the globe. There are some
   instances where altitude above Mean Sea Level is better. This example shows how 
@@ -30,7 +30,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Tracks the passing of 2000ms (2 seconds)
@@ -39,13 +39,13 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 }

--- a/examples/Example11_ResetModule/Example1_FactoryDefaultviaI2C/Example1_FactoryDefaultviaI2C.ino
+++ b/examples/Example11_ResetModule/Example1_FactoryDefaultviaI2C/Example1_FactoryDefaultviaI2C.ino
@@ -19,20 +19,20 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 
@@ -44,7 +44,7 @@ void setup()
 
   if (myGPS.begin() == false) //Attempt to re-connect
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example11_ResetModule/Example1_FactoryDefaultviaI2C/Example1_FactoryDefaultviaI2C.ino
+++ b/examples/Example11_ResetModule/Example1_FactoryDefaultviaI2C/Example1_FactoryDefaultviaI2C.ino
@@ -19,7 +19,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Example11_ResetModule/Example2_FactoryDefaultsviaSerial/Example2_FactoryDefaultsviaSerial.ino
+++ b/examples/Example11_ResetModule/Example2_FactoryDefaultsviaSerial/Example2_FactoryDefaultsviaSerial.ino
@@ -19,7 +19,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 int state = 0; // steps through auto-baud, reset, etc states

--- a/examples/Example11_ResetModule/Example2_FactoryDefaultsviaSerial/Example2_FactoryDefaultsviaSerial.ino
+++ b/examples/Example11_ResetModule/Example2_FactoryDefaultsviaSerial/Example2_FactoryDefaultsviaSerial.ino
@@ -19,7 +19,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 int state = 0; // steps through auto-baud, reset, etc states
@@ -28,7 +28,7 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 }
 
 void loop()

--- a/examples/Example12_UseUart/Example12_UseUart.ino
+++ b/examples/Example12_UseUart/Example12_UseUart.ino
@@ -27,7 +27,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 #include <SoftwareSerial.h>

--- a/examples/Example12_UseUart/Example12_UseUart.ino
+++ b/examples/Example12_UseUart/Example12_UseUart.ino
@@ -27,19 +27,19 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 #include <SoftwareSerial.h>
 SoftwareSerial mySerial(10, 11); // RX, TX. Pin 10 on Uno goes to TX pin on GPS module.
 
-long lastTime = 0; //Simple local timer. Limits amount of I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount of I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   //Assume that the U-Blox GPS is running at 9600 baud (the default) or at 38400 baud.
   //Loop until we're in sync and then ensure it's at 38400 baud.

--- a/examples/Example13_PVT/Example1_AutoPVT/Example1_AutoPVT.ino
+++ b/examples/Example13_PVT/Example1_AutoPVT/Example1_AutoPVT.ino
@@ -28,7 +28,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Example13_PVT/Example1_AutoPVT/Example1_AutoPVT.ino
+++ b/examples/Example13_PVT/Example1_AutoPVT/Example1_AutoPVT.ino
@@ -28,20 +28,20 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example13_PVT/Example2_AutoPVT_ExplicitUpdate/Example2_AutoPVT_ExplicitUpdate.ino
+++ b/examples/Example13_PVT/Example2_AutoPVT_ExplicitUpdate/Example2_AutoPVT_ExplicitUpdate.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
@@ -37,13 +37,13 @@ void setup()
   Serial.begin(115200);
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example13_PVT/Example2_AutoPVT_ExplicitUpdate/Example2_AutoPVT_ExplicitUpdate.ino
+++ b/examples/Example13_PVT/Example2_AutoPVT_ExplicitUpdate/Example2_AutoPVT_ExplicitUpdate.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Example13_PVT/Example3_AssumeAutoPVTviaUart/Example3_AssumeAutoPVTviaUart.ino
+++ b/examples/Example13_PVT/Example3_AssumeAutoPVTviaUart/Example3_AssumeAutoPVTviaUart.ino
@@ -24,7 +24,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Example13_PVT/Example3_AssumeAutoPVTviaUart/Example3_AssumeAutoPVTviaUart.ino
+++ b/examples/Example13_PVT/Example3_AssumeAutoPVTviaUart/Example3_AssumeAutoPVTviaUart.ino
@@ -24,14 +24,14 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example 17");
+  Serial.println("SparkFun u-blox Example 17");
 
   //Use any Serial port with at least a Rx Pin connected or a receive only version of SoftwareSerial here
   //Assume that the U-Blox GPS is running at 9600 baud (the default)

--- a/examples/Example14_DebugOutput/Example14_DebugOutput.ino
+++ b/examples/Example14_DebugOutput/Example14_DebugOutput.ino
@@ -22,7 +22,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example14_DebugOutput/Example14_DebugOutput.ino
+++ b/examples/Example14_DebugOutput/Example14_DebugOutput.ino
@@ -22,22 +22,22 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example15_GetDateTime/Example15_GetDateTime.ino
+++ b/examples/Example15_GetDateTime/Example15_GetDateTime.ino
@@ -1,12 +1,12 @@
 /*
-  Getting time and date using Ublox commands
+  Getting time and date using u-blox commands
   By: davidallenmann
   SparkFun Electronics
   Date: April 16th, 2019
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for the current time and date. We also
+  This example shows how to query a u-blox module for the current time and date. We also
   turn off the NMEA output on the I2C port. This decreases the amount of I2C traffic
   dramatically.
 
@@ -26,23 +26,23 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example15_GetDateTime/Example15_GetDateTime.ino
+++ b/examples/Example15_GetDateTime/Example15_GetDateTime.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example16_Nanosecond_MaxOutput/Example16_Nanosecond_MaxOutput.ino
+++ b/examples/Example16_Nanosecond_MaxOutput/Example16_Nanosecond_MaxOutput.ino
@@ -1,12 +1,12 @@
 /*
-  Getting time and date using Ublox commands
+  Getting time and date using u-blox commands
   By: davidallenmann
   SparkFun Electronics
   Date: April 16th, 2019
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for the current time and date. We also
+  This example shows how to query a u-blox module for the current time and date. We also
   turn off the NMEA output on the I2C port. This decreases the amount of I2C traffic
   dramatically.
 
@@ -26,24 +26,24 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(500000); //Increase serial speed to maximize
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
   Wire.setClock(400000);
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example16_Nanosecond_MaxOutput/Example16_Nanosecond_MaxOutput.ino
+++ b/examples/Example16_Nanosecond_MaxOutput/Example16_Nanosecond_MaxOutput.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example16_PartialSecond_MaxOutput/Example16_PartialSecond_MaxOutput.ino
+++ b/examples/Example16_PartialSecond_MaxOutput/Example16_PartialSecond_MaxOutput.ino
@@ -1,5 +1,5 @@
 /*
-  Getting time and date using Ublox commands
+  Getting time and date using u-blox commands
   By: Nathan Seidle
   SparkFun Electronics
   Date: April 16th, 2019
@@ -25,24 +25,24 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(500000); //Increase serial speed to maximize
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
   Wire.setClock(400000);
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example16_PartialSecond_MaxOutput/Example16_PartialSecond_MaxOutput.ino
+++ b/examples/Example16_PartialSecond_MaxOutput/Example16_PartialSecond_MaxOutput.ino
@@ -25,7 +25,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example17_Geofence/Example17_Geofence.ino
+++ b/examples/Example17_Geofence/Example17_Geofence.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> // Needed for I2C
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Example17_Geofence/Example17_Geofence.ino
+++ b/examples/Example17_Geofence/Example17_Geofence.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> // Needed for I2C
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
@@ -51,9 +51,9 @@ void setup()
 
   delay(1000); // Let the GPS power up
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example18_PowerSaveMode/Example18_PowerSaveMode.ino
+++ b/examples/Example18_PowerSaveMode/Example18_PowerSaveMode.ino
@@ -40,7 +40,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example18_PowerSaveMode/Example18_PowerSaveMode.ino
+++ b/examples/Example18_PowerSaveMode/Example18_PowerSaveMode.ino
@@ -10,7 +10,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to put the Ublox module into power save mode and then
+  This example shows how to put the u-blox module into power save mode and then
   query its lat/long/altitude. We also turn off the NMEA output on the I2C port.
   This decreases the amount of I2C traffic dramatically.
 
@@ -40,23 +40,23 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example19_DynamicModel/Example19_DynamicModel.ino
+++ b/examples/Example19_DynamicModel/Example19_DynamicModel.ino
@@ -10,7 +10,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to change the Ublox module's dynamic platform model and then
+  This example shows how to change the u-blox module's dynamic platform model and then
   query its lat/long/altitude. We also turn off the NMEA output on the I2C port.
   This decreases the amount of I2C traffic dramatically.
 
@@ -37,25 +37,25 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println(F("SparkFun Ublox Example"));
+  Serial.println(F("SparkFun u-blox Example"));
 
   Wire.begin();
 
   //myGPS.enableDebugging(); // Uncomment this line to enable debug messages
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example19_DynamicModel/Example19_DynamicModel.ino
+++ b/examples/Example19_DynamicModel/Example19_DynamicModel.ino
@@ -37,7 +37,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example1_BasicNMEARead/Example1_BasicNMEARead.ino
+++ b/examples/Example1_BasicNMEARead/Example1_BasicNMEARead.ino
@@ -1,12 +1,12 @@
 /*
-  Read NMEA sentences over I2C using Ublox module SAM-M8Q, NEO-M8P, ZED-F9P, etc
+  Read NMEA sentences over I2C using u-blox module SAM-M8Q, NEO-M8P, ZED-F9P, etc
   By: Nathan Seidle
   SparkFun Electronics
   Date: August 22nd, 2018
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example reads the NMEA setences from the Ublox module over I2c and outputs
+  This example reads the NMEA setences from the u-blox module over I2c and outputs
   them to the serial port
   
   Feel like supporting open source hardware?
@@ -29,13 +29,13 @@ SFE_UBLOX_GPS myGPS;
 void setup()
 {
   Serial.begin(115200);
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   if (myGPS.begin() == false)
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example20_SendCustomCommand/Example20_SendCustomCommand.ino
+++ b/examples/Example20_SendCustomCommand/Example20_SendCustomCommand.ino
@@ -36,7 +36,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
@@ -44,15 +44,15 @@ void setup()
   Serial.begin(115200); // You may need to increase this for high navigation rates!
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   //myGPS.enableDebugging(); // Uncomment this line to enable debug messages
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/Example20_SendCustomCommand/Example20_SendCustomCommand.ino
+++ b/examples/Example20_SendCustomCommand/Example20_SendCustomCommand.ino
@@ -36,7 +36,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Example21_ModuleInfo/Example21_ModuleInfo.ino
+++ b/examples/Example21_ModuleInfo/Example21_ModuleInfo.ino
@@ -39,7 +39,7 @@
 
 #define MAX_PAYLOAD_SIZE 384 // Override MAX_PAYLOAD_SIZE for getModuleInfo which can return up to 348 bytes
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 
 // Extend the class for getModuleInfo
 class SFE_UBLOX_GPS_ADD : public SFE_UBLOX_GPS

--- a/examples/Example21_ModuleInfo/Example21_ModuleInfo.ino
+++ b/examples/Example21_ModuleInfo/Example21_ModuleInfo.ino
@@ -39,7 +39,7 @@
 
 #define MAX_PAYLOAD_SIZE 384 // Override MAX_PAYLOAD_SIZE for getModuleInfo which can return up to 348 bytes
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 
 // Extend the class for getModuleInfo
 class SFE_UBLOX_GPS_ADD : public SFE_UBLOX_GPS
@@ -63,15 +63,15 @@ void setup()
     Serial.begin(115200); // You may need to increase this for high navigation rates!
     while (!Serial)
         ; //Wait for user to open terminal
-    Serial.println(F("SparkFun Ublox Example"));
+    Serial.println(F("SparkFun u-blox Example"));
 
     Wire.begin();
 
     //myGPS.enableDebugging(); // Uncomment this line to enable debug messages
 
-    if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+    if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
     {
-        Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+        Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
         while (1)
             ;
     }

--- a/examples/Example22_PowerOff/Example22_PowerOff.ino
+++ b/examples/Example22_PowerOff/Example22_PowerOff.ino
@@ -26,7 +26,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 // define a digital pin capable of driving HIGH and LOW
@@ -59,15 +59,15 @@ void setup() {
 
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   //myGPS.enableDebugging(); // Enable debug messages
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example22_PowerOff/Example22_PowerOff.ino
+++ b/examples/Example22_PowerOff/Example22_PowerOff.ino
@@ -26,7 +26,7 @@
   Open the serial monitor at 115200 baud to see the output
 */
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 // define a digital pin capable of driving HIGH and LOW

--- a/examples/Example2_NMEAParsing/Example2_NMEAParsing.ino
+++ b/examples/Example2_NMEAParsing/Example2_NMEAParsing.ino
@@ -1,5 +1,5 @@
 /*
-  Read NMEA sentences over I2C using Ublox module SAM-M8Q, NEO-M8P, etc
+  Read NMEA sentences over I2C using u-blox module SAM-M8Q, NEO-M8P, etc
   By: Nathan Seidle
   SparkFun Electronics
   Date: August 22nd, 2018
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 #include <MicroNMEA.h> //http://librarymanager/All#MicroNMEA
@@ -36,13 +36,13 @@ MicroNMEA nmea(nmeaBuffer, sizeof(nmeaBuffer));
 void setup()
 {
   Serial.begin(115200);
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   if (myGPS.begin() == false)
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 }
@@ -71,13 +71,13 @@ void loop()
   delay(250); //Don't pound too hard on the I2C bus
 }
 
-//This function gets called from the SparkFun Ublox Arduino Library
+//This function gets called from the SparkFun u-blox Arduino Library
 //As each NMEA character comes in you can specify what to do with it
 //Useful for passing to other libraries like tinyGPS, MicroNMEA, or even
 //a buffer, radio, etc.
 void SFE_UBLOX_GPS::processNMEA(char incoming)
 {
-  //Take the incoming char from the Ublox I2C port and pass it on to the MicroNMEA lib
+  //Take the incoming char from the u-blox I2C port and pass it on to the MicroNMEA lib
   //for sentence cracking
   nmea.process(incoming);
 }

--- a/examples/Example2_NMEAParsing/Example2_NMEAParsing.ino
+++ b/examples/Example2_NMEAParsing/Example2_NMEAParsing.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 #include <MicroNMEA.h> //http://librarymanager/All#MicroNMEA

--- a/examples/Example3_GetPosition/Example3_GetPosition.ino
+++ b/examples/Example3_GetPosition/Example3_GetPosition.ino
@@ -6,7 +6,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for its lat/long/altitude. We also
+  This example shows how to query a u-blox module for its lat/long/altitude. We also
   turn off the NMEA output on the I2C port. This decreases the amount of I2C traffic 
   dramatically.
 
@@ -30,22 +30,22 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example3_GetPosition/Example3_GetPosition.ino
+++ b/examples/Example3_GetPosition/Example3_GetPosition.ino
@@ -30,7 +30,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example4_FixType/Example4_FixType.ino
+++ b/examples/Example4_FixType/Example4_FixType.ino
@@ -34,7 +34,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example4_FixType/Example4_FixType.ino
+++ b/examples/Example4_FixType/Example4_FixType.ino
@@ -6,7 +6,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for fix type and RTK fix type.
+  This example shows how to query a u-blox module for fix type and RTK fix type.
   The fix type is as follows:
     0 = no fix
     1 = dead reckoning (requires external sensors)
@@ -34,23 +34,23 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
   Wire.setClock(400000); //Optional. Increase I2C clock speed to 400kHz.
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 }

--- a/examples/Example5_SpeedHeadingPrecision/Example5_SpeedHeadingPrecision.ino
+++ b/examples/Example5_SpeedHeadingPrecision/Example5_SpeedHeadingPrecision.ino
@@ -6,7 +6,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for its lat/long/altitude.
+  This example shows how to query a u-blox module for its lat/long/altitude.
 
   Note: Long/lat are large numbers because they are * 10^7. To convert lat/long
   to something google maps understands simply divide the numbers by 1,000,000. We
@@ -28,22 +28,22 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 }

--- a/examples/Example5_SpeedHeadingPrecision/Example5_SpeedHeadingPrecision.ino
+++ b/examples/Example5_SpeedHeadingPrecision/Example5_SpeedHeadingPrecision.ino
@@ -28,7 +28,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example6_EnableNMEASentences/Example6_EnableNMEASentences.ino
+++ b/examples/Example6_EnableNMEASentences/Example6_EnableNMEASentences.ino
@@ -7,9 +7,9 @@
   basically do whatever you want with this code.
 
   This example shows how to turn on/off the NMEA sentences being output
-  over UART1. We use the I2C interface on the Ublox module for configuration
+  over UART1. We use the I2C interface on the u-blox module for configuration
   but you won't see any output from this sketch. You'll need to hook up
-  a Serial Basic or other USB to Serial device to UART1 on your Ublox module
+  a Serial Basic or other USB to Serial device to UART1 on your u-blox module
   to see the output.
 
   This example turns off all sentences except for the GPGGA and GPVTG sentences.
@@ -24,7 +24,7 @@
   Plug a Qwiic cable into the GPS and a RedBoard
   If you don't have a platform with a Qwiic connection use the SparkFun Qwiic Breadboard Jumper (https://www.sparkfun.com/products/14425)
   Open the serial monitor at 115200 baud to see the output
-  Hookup a Serial Basic (https://www.sparkfun.com/products/15096) to UART1 on the Ublox module. Open a terminal at 57600bps
+  Hookup a Serial Basic (https://www.sparkfun.com/products/15096) to UART1 on the u-blox module. Open a terminal at 57600bps
   and see GPGGA and GPVTG sentences.
 */
 #include <Wire.h> //Needed for I2C to GPS
@@ -43,7 +43,7 @@ void setup()
 
   if (myGPS.begin() == false)
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }
@@ -66,7 +66,7 @@ void setup()
 
   myGPS.saveConfiguration(); //Save these settings to NVM
 
-  Serial.println(F("Messages configured. NMEA now being output over the UART1 port on the Ublox module at 57600bps."));
+  Serial.println(F("Messages configured. NMEA now being output over the UART1 port on the u-blox module at 57600bps."));
 }
 
 void loop()

--- a/examples/Example7_OutputRate/Example7_OutputRate.ino
+++ b/examples/Example7_OutputRate/Example7_OutputRate.ino
@@ -29,7 +29,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example7_OutputRate/Example7_OutputRate.ino
+++ b/examples/Example7_OutputRate/Example7_OutputRate.ino
@@ -29,10 +29,10 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 long startTime = 0; //Used to calc the actual update rate.
 long updateCount = 0; //Used to calc the actual update rate.
 
@@ -40,14 +40,14 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
   Wire.setClock(400000);
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example8_GetProtocolVersion/Example8_GetProtocolVersion.ino
+++ b/examples/Example8_GetProtocolVersion/Example8_GetProtocolVersion.ino
@@ -28,7 +28,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/Example8_GetProtocolVersion/Example8_GetProtocolVersion.ino
+++ b/examples/Example8_GetProtocolVersion/Example8_GetProtocolVersion.ino
@@ -1,12 +1,12 @@
 /*
-  Reading the protocol version of a Ublox module
+  Reading the protocol version of a u-blox module
   By: Nathan Seidle
   SparkFun Electronics
   Date: January 3rd, 2019
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for its protocol version.
+  This example shows how to query a u-blox module for its protocol version.
 
   Various modules have various protocol version. We've seen v18 up to v27. Depending
   on the protocol version there are different commands available. This is a handy
@@ -28,22 +28,22 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Example9_ChangeI2CAddress/Example9_ChangeI2CAddress.ino
+++ b/examples/Example9_ChangeI2CAddress/Example9_ChangeI2CAddress.ino
@@ -22,7 +22,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Tracks the passing of 2000ms (2 seconds)

--- a/examples/Example9_ChangeI2CAddress/Example9_ChangeI2CAddress.ino
+++ b/examples/Example9_ChangeI2CAddress/Example9_ChangeI2CAddress.ino
@@ -1,12 +1,12 @@
 /*
-  Change the I2C address of a Ublox module using I2C
+  Change the I2C address of a u-blox module using I2C
   By: Nathan Seidle
   SparkFun Electronics
   Date: January 3rd, 2019
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to change the I2C address of a Ublox module
+  This example shows how to change the I2C address of a u-blox module
 
   Feel like supporting open source hardware?
   Buy a board from SparkFun!
@@ -22,7 +22,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Tracks the passing of 2000ms (2 seconds)
@@ -31,11 +31,11 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  byte oldAddress = 0x42; //The default address for Ublox modules is 0x42
+  byte oldAddress = 0x42; //The default address for u-blox modules is 0x42
   byte newAddress = 0x3F; //Address you want to change to. Valid is 0x08 to 0x77.
 
   while (Serial.available()) Serial.read(); //Trash any incoming chars
@@ -43,7 +43,7 @@ void setup()
   Serial.println(newAddress, HEX);
   while (Serial.available() == false) ; //Wait for user to send character
   
-  if (myGPS.begin(Wire, oldAddress) == true) //Connect to the Ublox module using Wire port and the old address
+  if (myGPS.begin(Wire, oldAddress) == true) //Connect to the u-blox module using Wire port and the old address
   {
     Serial.print("GPS found at address 0x");
     Serial.println(oldAddress, HEX);

--- a/examples/NEO-M8P-2/Example1_EnableRTCM/Example1_EnableRTCM.ino
+++ b/examples/NEO-M8P-2/Example1_EnableRTCM/Example1_EnableRTCM.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/NEO-M8P-2/Example1_EnableRTCM/Example1_EnableRTCM.ino
+++ b/examples/NEO-M8P-2/Example1_EnableRTCM/Example1_EnableRTCM.ino
@@ -1,5 +1,5 @@
 /*
-  Send UBX binary commands to enable RTCM sentences on Ublox NEO-M8P module
+  Send UBX binary commands to enable RTCM sentences on u-blox NEO-M8P module
   By: Nathan Seidle
   SparkFun Electronics
   Date: September 7th, 2018
@@ -24,21 +24,21 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while(!Serial); //Wait for user to open terminal
-  Serial.println("Ublox RTCM Enable Example");
+  Serial.println("u-blox RTCM Enable Example");
 
   Wire.begin();
   Wire.setClock(400000); //Increase I2C clock speed to 400kHz
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/NEO-M8P-2/Example2_StartRTCMBase/Example2_StartRTCMBase.ino
+++ b/examples/NEO-M8P-2/Example2_StartRTCMBase/Example2_StartRTCMBase.ino
@@ -1,5 +1,5 @@
 /*
-  Send UBX binary commands to enable RTCM sentences on Ublox NEO-M8P-2 module
+  Send UBX binary commands to enable RTCM sentences on u-blox NEO-M8P-2 module
   By: Nathan Seidle
   SparkFun Electronics
   Date: September 7th, 2018
@@ -26,21 +26,21 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("Ublox NEO-M8P-2 base station example");
+  Serial.println("u-blox NEO-M8P-2 base station example");
 
   Wire.begin();
   Wire.setClock(400000); //Increase I2C clock speed to 400kHz
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 
@@ -140,7 +140,7 @@ void loop()
   delay(250); //Don't pound too hard on the I2C bus
 }
 
-//This function gets called from the SparkFun Ublox Arduino Library.
+//This function gets called from the SparkFun u-blox Arduino Library.
 //As each RTCM byte comes in you can specify what to do with it
 //Useful for passing the RTCM correction data to a radio, Ntrip broadcaster, etc.
 void SFE_UBLOX_GPS::processRTCM(uint8_t incoming)

--- a/examples/NEO-M8P-2/Example2_StartRTCMBase/Example2_StartRTCMBase.ino
+++ b/examples/NEO-M8P-2/Example2_StartRTCMBase/Example2_StartRTCMBase.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/NEO-M8P-2/Example3_BaseWithLCD/Example3_BaseWithLCD.ino
+++ b/examples/NEO-M8P-2/Example3_BaseWithLCD/Example3_BaseWithLCD.ino
@@ -1,5 +1,5 @@
 /*
-  Send UBX binary commands to enable RTCM sentences on Ublox NEO-M8P-2 module
+  Send UBX binary commands to enable RTCM sentences on u-blox NEO-M8P-2 module
   By: Nathan Seidle
   SparkFun Electronics
   Date: September 7th, 2018
@@ -39,7 +39,7 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("Ublox GPS I2C Test");
+  Serial.println("u-blox GPS I2C Test");
 
   Wire.begin();
 
@@ -54,7 +54,7 @@ void setup()
   myGPS.begin(Wire);
   if (myGPS.isConnected() == false)
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     lcd.setCursor(0, 1);
     lcd.print(F("No GPS detected"));
     while (1);
@@ -172,7 +172,7 @@ void loop()
   delay(250); //Don't pound too hard on the I2C bus
 }
 
-//This function gets called from the SparkFun Ublox Arduino Library.
+//This function gets called from the SparkFun u-blox Arduino Library.
 //As each RTCM byte comes in you can specify what to do with it
 //Useful for passing the RTCM correction data to a radio, Ntrip broadcaster, etc.
 void SFE_UBLOX_GPS::processRTCM(uint8_t incoming)

--- a/examples/Series_6_7/Example1_GetPositionAndTime_Series_6_7/Example1_GetPositionAndTime_Series_6_7.ino
+++ b/examples/Series_6_7/Example1_GetPositionAndTime_Series_6_7/Example1_GetPositionAndTime_Series_6_7.ino
@@ -8,7 +8,7 @@
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  This example shows how to query a Ublox module for its lat/long/altitude. We also
+  This example shows how to query a u-blox module for its lat/long/altitude. We also
   turn off the NMEA output on the I2C port. This decreases the amount of I2C traffic 
   dramatically.
 
@@ -35,21 +35,21 @@
 #include "SparkFun_Ublox_Arduino_Library_Series_6_7.h"
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   //myGPS.enableDebugging(); // Uncomment this line to enable debug messages
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/Series_6_7/Example1_GetPositionAndTime_Series_6_7/SparkFun_Ublox_Arduino_Library_Series_6_7.cpp
+++ b/examples/Series_6_7/Example1_GetPositionAndTime_Series_6_7/SparkFun_Ublox_Arduino_Library_Series_6_7.cpp
@@ -1,5 +1,5 @@
 /*
-  This is a library written for the Ublox ZED-F9P and NEO-M8P-2
+  This is a library written for the u-blox ZED-F9P and NEO-M8P-2
 
   Updated: June 16th, 2020
 
@@ -20,7 +20,7 @@
   Original library written by Nathan Seidle @ SparkFun Electronics, September 6th, 2018
 
   This library handles configuring and handling the responses
-  from a Ublox GPS module. Works with most modules from Ublox including
+  from a u-blox GPS module. Works with most modules from u-blox including
   the Zed-F9P, NEO-M8P-2, NEO-M9N, ZOE-M8Q, SAM-M8Q, and many others.
 
   https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library
@@ -213,7 +213,7 @@ void SFE_UBLOX_GPS::hardReset()
   sendCommand(&packetCfg, 0); // don't expect ACK
 }
 
-//Changes the serial baud rate of the Ublox module, can't return success/fail 'cause ACK from modem
+//Changes the serial baud rate of the u-blox module, can't return success/fail 'cause ACK from modem
 //is lost due to baud rate change
 void SFE_UBLOX_GPS::setSerialRate(uint32_t baudrate, uint8_t uartPort, uint16_t maxWait)
 {
@@ -251,7 +251,7 @@ void SFE_UBLOX_GPS::setSerialRate(uint32_t baudrate, uint8_t uartPort, uint16_t 
   }
 }
 
-//Changes the I2C address that the Ublox module responds to
+//Changes the I2C address that the u-blox module responds to
 //0x42 is the default but can be changed with this command
 boolean SFE_UBLOX_GPS::setI2CAddress(uint8_t deviceAddress, uint16_t maxWait)
 {
@@ -317,10 +317,10 @@ boolean SFE_UBLOX_GPS::checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedCl
       uint8_t lsb = _i2cPort->read();
       if (lsb == 0xFF)
       {
-        //I believe this is a Ublox bug. Device should never present an 0xFF.
+        //I believe this is a u-blox bug. Device should never present an 0xFF.
         if ((_printDebug == true) || (_printLimitedDebug == true)) // Print this if doing limited debugging
         {
-          _debugSerial->println(F("checkUbloxI2C: Ublox bug, length lsb is 0xFF"));
+          _debugSerial->println(F("checkUbloxI2C: u-blox bug, length lsb is 0xFF"));
         }
         if (checksumFailurePin >= 0)
         {
@@ -413,7 +413,7 @@ boolean SFE_UBLOX_GPS::checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedCl
             {
               if ((_printDebug == true) || (_printLimitedDebug == true)) // Print this if doing limited debugging
               {
-                _debugSerial->println(F("checkUbloxU2C: Ublox error, module not ready with data"));
+                _debugSerial->println(F("checkUbloxU2C: u-blox error, module not ready with data"));
               }
               delay(5); //In logic analyzation, the module starting responding after 1.48ms
               if (checksumFailurePin >= 0)
@@ -1664,7 +1664,7 @@ boolean SFE_UBLOX_GPS::factoryDefault(uint16_t maxWait)
 
 //Given a group, ID and size, return the value of this config spot
 //The 32-bit key is put together from group/ID/size. See other getVal to send key directly.
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::getVal8(uint16_t group, uint16_t id, uint8_t size, uint8_t layer, uint16_t maxWait)
 {
   //Create key
@@ -1686,7 +1686,7 @@ uint8_t SFE_UBLOX_GPS::getVal8(uint16_t group, uint16_t id, uint8_t size, uint8_
 //Given a key, return its value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -1748,7 +1748,7 @@ uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
 //Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
   return setVal16(key, value, layer, maxWait);
@@ -1757,7 +1757,7 @@ uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint1
 //Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -1789,7 +1789,7 @@ uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uin
 //Given a key, set an 8-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -1820,7 +1820,7 @@ uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint1
 //Given a key, set a 32-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal32(uint32_t key, uint32_t value, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -1854,7 +1854,7 @@ uint8_t SFE_UBLOX_GPS::setVal32(uint32_t key, uint32_t value, uint8_t layer, uin
 //Start defining a new UBX-CFG-VALSET ubxPacket
 //This function takes a full 32-bit key and 32-bit value
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::newCfgValset32(uint32_t key, uint32_t value, uint8_t layer)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -1888,7 +1888,7 @@ uint8_t SFE_UBLOX_GPS::newCfgValset32(uint32_t key, uint32_t value, uint8_t laye
 //Start defining a new UBX-CFG-VALSET ubxPacket
 //This function takes a full 32-bit key and 16-bit value
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::newCfgValset16(uint32_t key, uint16_t value, uint8_t layer)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -1920,7 +1920,7 @@ uint8_t SFE_UBLOX_GPS::newCfgValset16(uint32_t key, uint16_t value, uint8_t laye
 //Start defining a new UBX-CFG-VALSET ubxPacket
 //This function takes a full 32-bit key and 8-bit value
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::newCfgValset8(uint32_t key, uint8_t value, uint8_t layer)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -3133,7 +3133,7 @@ uint16_t SFE_UBLOX_GPS::getPDOP(uint16_t maxWait)
   return (pDOP);
 }
 
-//Get the current protocol version of the Ublox module we're communicating with
+//Get the current protocol version of the u-blox module we're communicating with
 //This is helpful when deciding if we should call the high-precision Lat/Long (HPPOSLLH) or the regular (POSLLH)
 uint8_t SFE_UBLOX_GPS::getProtocolVersionHigh(uint16_t maxWait)
 {
@@ -3142,7 +3142,7 @@ uint8_t SFE_UBLOX_GPS::getProtocolVersionHigh(uint16_t maxWait)
   return (versionHigh);
 }
 
-//Get the current protocol version of the Ublox module we're communicating with
+//Get the current protocol version of the u-blox module we're communicating with
 //This is helpful when deciding if we should call the high-precision Lat/Long (HPPOSLLH) or the regular (POSLLH)
 uint8_t SFE_UBLOX_GPS::getProtocolVersionLow(uint16_t maxWait)
 {
@@ -3151,7 +3151,7 @@ uint8_t SFE_UBLOX_GPS::getProtocolVersionLow(uint16_t maxWait)
   return (versionLow);
 }
 
-//Get the current protocol version of the Ublox module we're communicating with
+//Get the current protocol version of the u-blox module we're communicating with
 //This is helpful when deciding if we should call the high-precision Lat/Long (HPPOSLLH) or the regular (POSLLH)
 boolean SFE_UBLOX_GPS::getProtocolVersion(uint16_t maxWait)
 {

--- a/examples/Series_6_7/Example1_GetPositionAndTime_Series_6_7/SparkFun_Ublox_Arduino_Library_Series_6_7.h
+++ b/examples/Series_6_7/Example1_GetPositionAndTime_Series_6_7/SparkFun_Ublox_Arduino_Library_Series_6_7.h
@@ -1,5 +1,5 @@
 /*
-  This is a library written for the Ublox ZED-F9P and NEO-M8P-2
+  This is a library written for the u-blox ZED-F9P and NEO-M8P-2
 
   Updated: June 16th, 2020
 
@@ -20,7 +20,7 @@
   Original library written by Nathan Seidle @ SparkFun Electronics, September 6th, 2018
 
   This library handles configuring and handling the responses
-  from a Ublox GPS module. Works with most modules from Ublox including
+  from a u-blox GPS module. Works with most modules from u-blox including
   the Zed-F9P, NEO-M8P-2, NEO-M9N, ZOE-M8Q, SAM-M8Q, and many others.
 
   https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library
@@ -190,9 +190,9 @@ const uint8_t UBX_CFG_SBAS = 0x16;		//SBAS configuration
 const uint8_t UBX_CFG_TMODE3 = 0x71;	//Time Mode Settings 3. Used to enable Survey In Mode
 const uint8_t UBX_CFG_TP5 = 0x31;		//Time Pulse Parameters
 const uint8_t UBX_CFG_USB = 0x1B;		//USB Configuration
-const uint8_t UBX_CFG_VALDEL = 0x8C;	//Used for config of higher version Ublox modules (ie protocol v27 and above). Deletes values corresponding to provided keys/ provided keys with a transaction
-const uint8_t UBX_CFG_VALGET = 0x8B;	//Used for config of higher version Ublox modules (ie protocol v27 and above). Configuration Items
-const uint8_t UBX_CFG_VALSET = 0x8A;	//Used for config of higher version Ublox modules (ie protocol v27 and above). Sets values corresponding to provided key-value pairs/ provided key-value pairs within a transaction.
+const uint8_t UBX_CFG_VALDEL = 0x8C;	//Used for config of higher version u-blox modules (ie protocol v27 and above). Deletes values corresponding to provided keys/ provided keys with a transaction
+const uint8_t UBX_CFG_VALGET = 0x8B;	//Used for config of higher version u-blox modules (ie protocol v27 and above). Configuration Items
+const uint8_t UBX_CFG_VALSET = 0x8A;	//Used for config of higher version u-blox modules (ie protocol v27 and above). Sets values corresponding to provided key-value pairs/ provided key-value pairs within a transaction.
 
 //The following are used to enable NMEA messages. Descriptions come from the NMEA messages overview in the ZED-F9P Interface Description
 const uint8_t UBX_NMEA_MSB = 0xF0;	//All NMEA enable commands have 0xF0 as MSB
@@ -517,8 +517,8 @@ public:
 	void factoryReset(); //Send factory reset sequence (i.e. load "default" configuration and perform hardReset)
 	void hardReset();	 //Perform a reset leading to a cold start (zero info start-up)
 
-	boolean setI2CAddress(uint8_t deviceAddress, uint16_t maxTime = 250);										 //Changes the I2C address of the Ublox module
-	void setSerialRate(uint32_t baudrate, uint8_t uartPort = COM_PORT_UART1, uint16_t maxTime = defaultMaxWait); //Changes the serial baud rate of the Ublox module, uartPort should be COM_PORT_UART1/2
+	boolean setI2CAddress(uint8_t deviceAddress, uint16_t maxTime = 250);										 //Changes the I2C address of the u-blox module
+	void setSerialRate(uint32_t baudrate, uint8_t uartPort = COM_PORT_UART1, uint16_t maxTime = defaultMaxWait); //Changes the serial baud rate of the u-blox module, uartPort should be COM_PORT_UART1/2
 	void setNMEAOutputPort(Stream &nmeaOutputPort);																 //Sets the internal variable for the port to direct NMEA characters to
 
 	boolean setNavigationFrequency(uint8_t navFreq, uint16_t maxWait = defaultMaxWait);	 //Set the number of nav solutions sent per second

--- a/examples/ZED-F9P/Example10_GetHighPrecisionPositionAndAccuracy/Example10_GetHighPrecisionPositionAndAccuracy.ino
+++ b/examples/ZED-F9P/Example10_GetHighPrecisionPositionAndAccuracy/Example10_GetHighPrecisionPositionAndAccuracy.ino
@@ -23,10 +23,10 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
@@ -37,9 +37,9 @@ void setup()
 
   //myGPS.enableDebugging(Serial);
 
-  if (myGPS.begin(Wire) == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin(Wire) == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/ZED-F9P/Example10_GetHighPrecisionPositionAndAccuracy/Example10_GetHighPrecisionPositionAndAccuracy.ino
+++ b/examples/ZED-F9P/Example10_GetHighPrecisionPositionAndAccuracy/Example10_GetHighPrecisionPositionAndAccuracy.ino
@@ -23,7 +23,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example11_GetHighPrecisionPositionUsingDouble/Example11_GetHighPrecisionPositionUsingDouble.ino
+++ b/examples/ZED-F9P/Example11_GetHighPrecisionPositionUsingDouble/Example11_GetHighPrecisionPositionUsingDouble.ino
@@ -29,10 +29,10 @@
 #define myWire Wire // This will work on the Redboard Artemis and the Artemis Thing Plus using Qwiic
 //#define myWire Wire1 // Uncomment this line if you are using the extra SCL1/SDA1 pins (D17 and D16) on the Thing Plus
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
@@ -43,9 +43,9 @@ void setup()
 
   //myGPS.enableDebugging(Serial); // Uncomment this line to enable debug messages
 
-  if (myGPS.begin(myWire) == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin(myWire) == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
       ;
   }

--- a/examples/ZED-F9P/Example11_GetHighPrecisionPositionUsingDouble/Example11_GetHighPrecisionPositionUsingDouble.ino
+++ b/examples/ZED-F9P/Example11_GetHighPrecisionPositionUsingDouble/Example11_GetHighPrecisionPositionUsingDouble.ino
@@ -29,7 +29,7 @@
 #define myWire Wire // This will work on the Redboard Artemis and the Artemis Thing Plus using Qwiic
 //#define myWire Wire1 // Uncomment this line if you are using the extra SCL1/SDA1 pins (D17 and D16) on the Thing Plus
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example12_setStaticPosition/Example12_setStaticPosition.ino
+++ b/examples/ZED-F9P/Example12_setStaticPosition/Example12_setStaticPosition.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/ZED-F9P/Example12_setStaticPosition/Example12_setStaticPosition.ino
+++ b/examples/ZED-F9P/Example12_setStaticPosition/Example12_setStaticPosition.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/ZED-F9P/Example13_autoHPPOSLLH/Example13_autoHPPOSLLH.ino
+++ b/examples/ZED-F9P/Example13_autoHPPOSLLH/Example13_autoHPPOSLLH.ino
@@ -31,7 +31,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/ZED-F9P/Example13_autoHPPOSLLH/Example13_autoHPPOSLLH.ino
+++ b/examples/ZED-F9P/Example13_autoHPPOSLLH/Example13_autoHPPOSLLH.ino
@@ -31,23 +31,23 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_Ublox_GPS
+#include <SparkFun_Ublox_Arduino_Library.h> //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
   //myGPS.enableDebugging(); // Uncomment this line to enable lots of helpful debug messages
   //myGPS.enableDebugging(Serial, true); // Uncomment this line to enable the minimum of helpful debug messages
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/ZED-F9P/Example14_NTRIPServer/Example14_NTRIPServer.ino
+++ b/examples/ZED-F9P/Example14_NTRIPServer/Example14_NTRIPServer.ino
@@ -34,7 +34,7 @@
 WiFiClient client;
 
 #include <Wire.h> //Needed for I2C to GPS
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 //Basic Connection settings to RTK2Go NTRIP Caster - See secrets for mount specific credentials

--- a/examples/ZED-F9P/Example14_NTRIPServer/Example14_NTRIPServer.ino
+++ b/examples/ZED-F9P/Example14_NTRIPServer/Example14_NTRIPServer.ino
@@ -34,7 +34,7 @@
 WiFiClient client;
 
 #include <Wire.h> //Needed for I2C to GPS
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 //Basic Connection settings to RTK2Go NTRIP Caster - See secrets for mount specific credentials

--- a/examples/ZED-F9P/Example1_GetPositionAccuracy/Example1_GetPositionAccuracy.ino
+++ b/examples/ZED-F9P/Example1_GetPositionAccuracy/Example1_GetPositionAccuracy.ino
@@ -23,22 +23,22 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/ZED-F9P/Example1_GetPositionAccuracy/Example1_GetPositionAccuracy.ino
+++ b/examples/ZED-F9P/Example1_GetPositionAccuracy/Example1_GetPositionAccuracy.ino
@@ -23,7 +23,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example2_ValConfigurationMethod/Example2_ValConfigurationMethod.ino
+++ b/examples/ZED-F9P/Example2_ValConfigurationMethod/Example2_ValConfigurationMethod.ino
@@ -1,12 +1,12 @@
 /*
-  Configuring Ublox Module using new VALGET / VALSET / VALDEL methods
+  Configuring u-blox Module using new VALGET / VALSET / VALDEL methods
   By: Nathan Seidle
   SparkFun Electronics
   Date: January 3rd, 2019
   License: MIT. See license file for more information but you can
   basically do whatever you want with this code.
 
-  Ublox depricated many -CFG messages and replaced them with new
+  u-blox deprecated many -CFG messages and replaced them with new
   VALGET, VALSET, VALDEL methods. This shows the basics of how to use
   these methods.
 
@@ -26,22 +26,22 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("SparkFun Ublox Example");
+  Serial.println("SparkFun u-blox Example");
 
   Wire.begin();
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/ZED-F9P/Example2_ValConfigurationMethod/Example2_ValConfigurationMethod.ino
+++ b/examples/ZED-F9P/Example2_ValConfigurationMethod/Example2_ValConfigurationMethod.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example3_StartRTCMBase/Example3_StartRTCMBase.ino
+++ b/examples/ZED-F9P/Example3_StartRTCMBase/Example3_StartRTCMBase.ino
@@ -1,5 +1,5 @@
 /*
-  Send UBX binary commands to enable RTCM sentences on Ublox ZED-F9P module
+  Send UBX binary commands to enable RTCM sentences on u-blox ZED-F9P module
   By: Nathan Seidle
   SparkFun Electronics
   Date: January 9th, 2019
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 //#define USE_SERIAL1 // Uncomment this line to push the RTCM data to Serial1
@@ -35,7 +35,7 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("Ublox Base station example");
+  Serial.println("u-blox Base station example");
 
 #ifdef USE_SERIAL1
   // If our board supports it, we can output the RTCM data on Serial1
@@ -45,9 +45,9 @@ void setup()
   Wire.begin();
   Wire.setClock(400000); //Increase I2C clock speed to 400kHz
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 
@@ -158,7 +158,7 @@ void loop()
   delay(250); //Don't pound too hard on the I2C bus
 }
 
-//This function gets called from the SparkFun Ublox Arduino Library.
+//This function gets called from the SparkFun u-blox Arduino Library.
 //As each RTCM byte comes in you can specify what to do with it
 //Useful for passing the RTCM correction data to a radio, Ntrip broadcaster, etc.
 void SFE_UBLOX_GPS::processRTCM(uint8_t incoming)

--- a/examples/ZED-F9P/Example3_StartRTCMBase/Example3_StartRTCMBase.ino
+++ b/examples/ZED-F9P/Example3_StartRTCMBase/Example3_StartRTCMBase.ino
@@ -26,7 +26,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 //#define USE_SERIAL1 // Uncomment this line to push the RTCM data to Serial1

--- a/examples/ZED-F9P/Example4_BaseWithLCD/Example4_BaseWithLCD.ino
+++ b/examples/ZED-F9P/Example4_BaseWithLCD/Example4_BaseWithLCD.ino
@@ -1,5 +1,5 @@
 /*
-  Send UBX binary commands to enable RTCM sentences on Ublox ZED-F9P module
+  Send UBX binary commands to enable RTCM sentences on u-blox ZED-F9P module
   By: Nathan Seidle
   SparkFun Electronics
   Date: January 9th, 2019
@@ -40,7 +40,7 @@ void setup()
   Serial.begin(115200);
   while (!Serial)
     ; //Wait for user to open terminal
-  Serial.println("Ublox GPS I2C Test");
+  Serial.println("u-blox GPS I2C Test");
 
   Wire.begin();
 
@@ -55,7 +55,7 @@ void setup()
   myGPS.begin(Wire);
   if (myGPS.isConnected() == false)
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     lcd.setCursor(0, 1);
     lcd.print(F("No GPS detected"));
     while (1)
@@ -185,7 +185,7 @@ void loop()
   delay(250); //Don't pound too hard on the I2C bus
 }
 
-//This function gets called from the SparkFun Ublox Arduino Library.
+//This function gets called from the SparkFun u-blox Arduino Library.
 //As each RTCM byte comes in you can specify what to do with it
 //Useful for passing the RTCM correction data to a radio, Ntrip broadcaster, etc.
 void SFE_UBLOX_GPS::processRTCM(uint8_t incoming)

--- a/examples/ZED-F9P/Example5_RelativePositioningInformation/Example5_RelativePositioningInformation.ino
+++ b/examples/ZED-F9P/Example5_RelativePositioningInformation/Example5_RelativePositioningInformation.ino
@@ -1,5 +1,5 @@
 /*
-  Send UBX binary commands to enable RTCM sentences on Ublox ZED-F9P module
+  Send UBX binary commands to enable RTCM sentences on u-blox ZED-F9P module
   By: Nathan Seidle
   SparkFun Electronics
   Date: January 9th, 2019
@@ -23,7 +23,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 //#define USE_SERIAL1 // Uncomment this line to push the RTCM data from Serial1 to the module via I2C
@@ -34,7 +34,7 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial); //Wait for user to open terminal
-  Serial.println("Ublox Base station example");
+  Serial.println("u-blox Base station example");
 
 #ifdef USE_SERIAL1
   // If our board supports it, we can receive the RTCM data on Serial1
@@ -44,9 +44,9 @@ void setup()
   Wire.begin();
   Wire.setClock(400000); //Increase I2C clock speed to 400kHz
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
-    Serial.println(F("Ublox GPS not detected at default I2C address. Please check wiring. Freezing."));
+    Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1);
   }
 

--- a/examples/ZED-F9P/Example5_RelativePositioningInformation/Example5_RelativePositioningInformation.ino
+++ b/examples/ZED-F9P/Example5_RelativePositioningInformation/Example5_RelativePositioningInformation.ino
@@ -23,7 +23,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 //#define USE_SERIAL1 // Uncomment this line to push the RTCM data from Serial1 to the module via I2C

--- a/examples/ZED-F9P/Example6_GetVal/Example6_GetVal.ino
+++ b/examples/ZED-F9P/Example6_GetVal/Example6_GetVal.ino
@@ -24,10 +24,10 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
-long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 void setup()
 {
@@ -39,7 +39,7 @@ void setup()
   Wire.begin();
   Wire.setClock(400000); //Increase I2C clock speed to 400kHz
 
-  if (myGPS.begin() == false) //Connect to the Ublox module using Wire port
+  if (myGPS.begin() == false) //Connect to the u-blox module using Wire port
   {
     Serial.println(F("u-blox GPS not detected at default I2C address. Please check wiring. Freezing."));
     while (1)
@@ -51,7 +51,7 @@ void setup()
 
   uint8_t currentI2Caddress = myGPS.getVal8(UBLOX_CFG_I2C_ADDRESS);
   Serial.print("Current I2C address (should be 0x42): 0x");
-  Serial.println(currentI2Caddress >> 1, HEX); //Ublox module returns a shifted 8-bit address. Make it 7-bit unshifted.
+  Serial.println(currentI2Caddress >> 1, HEX); //u-blox module returns a shifted 8-bit address. Make it 7-bit unshifted.
 
   while (1)
     ;

--- a/examples/ZED-F9P/Example6_GetVal/Example6_GetVal.ino
+++ b/examples/ZED-F9P/Example6_GetVal/Example6_GetVal.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example7_SetVal/Example7_SetVal.ino
+++ b/examples/ZED-F9P/Example7_SetVal/Example7_SetVal.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example7_SetVal/Example7_SetVal.ino
+++ b/examples/ZED-F9P/Example7_SetVal/Example7_SetVal.ino
@@ -24,7 +24,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 long lastTime = 0; //Simple local timer. Limits amount if I2C traffic to u-blox module.

--- a/examples/ZED-F9P/Example8_GetSetPortSettings/Example8_GetSetPortSettings.ino
+++ b/examples/ZED-F9P/Example8_GetSetPortSettings/Example8_GetSetPortSettings.ino
@@ -23,7 +23,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/ZED-F9P/Example8_GetSetPortSettings/Example8_GetSetPortSettings.ino
+++ b/examples/ZED-F9P/Example8_GetSetPortSettings/Example8_GetSetPortSettings.ino
@@ -23,7 +23,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/ZED-F9P/Example9_multiSetVal/Example9_multiSetVal.ino
+++ b/examples/ZED-F9P/Example9_multiSetVal/Example9_multiSetVal.ino
@@ -25,7 +25,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_Ublox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/ZED-F9P/Example9_multiSetVal/Example9_multiSetVal.ino
+++ b/examples/ZED-F9P/Example9_multiSetVal/Example9_multiSetVal.ino
@@ -25,7 +25,7 @@
 
 #include <Wire.h> //Needed for I2C to GPS
 
-#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GPS
+#include "SparkFun_Ublox_Arduino_Library.h" //http://librarymanager/All#SparkFun_u-blox_GNSS
 SFE_UBLOX_GPS myGPS;
 
 void setup()

--- a/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Interface.cpp
+++ b/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Interface.cpp
@@ -1,6 +1,6 @@
 /*
-    This is an interface that connects the CPP Ublox library with the main C code.
-    Added to make it possible to run Ublox lib on Zephyr (NCS)
+    This is an interface that connects the CPP u-blox library with the main C code.
+    Added to make it possible to run u-blox lib on Zephyr (NCS)
 
     This port was made by Vid Rajtmajer <vid@irnas.eu>, www.irnas.eu
 */
@@ -15,7 +15,7 @@
 
 
 SFE_UBLOX_GPS myGPS; // driver class instance
-long lastTime = 0;   // Simple local timer. Limits amount if I2C traffic to Ublox module.
+long lastTime = 0;   // Simple local timer. Limits amount if I2C traffic to u-blox module.
 
 // init GPIO checksumFailurePin and load GPIO device pointer to the driver
 uint8_t set_gpio_dev(struct device *gpio_dev, uint8_t enable_debug)

--- a/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Interface.h
+++ b/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Interface.h
@@ -1,6 +1,6 @@
 /*
-    This is an interface that connects the CPP Ublox library with the main C code.
-    Added to make it possible to run Ublox lib on Zephyr (NCS)
+    This is an interface that connects the CPP u-blox library with the main C code.
+    Added to make it possible to run u-blox lib on Zephyr (NCS)
 
     This port was made by Vid Rajtmajer <vid@irnas.eu>, www.irnas.eu
 */

--- a/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Library.cpp
+++ b/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Library.cpp
@@ -1,5 +1,5 @@
 /*
-	This is a library written for the Ublox ZED-F9P and NEO-M8P-2
+	This is a library written for the u-blox ZED-F9P and NEO-M8P-2
 	SparkFun sells these at its website: www.sparkfun.com
 	Do you like this library? Help support SparkFun. Buy a board!
 	https://www.sparkfun.com/products/15136
@@ -11,7 +11,7 @@
 	Written by Nathan Seidle @ SparkFun Electronics, September 6th, 2018
 
 	This library handles configuring and handling the responses
-	from a Ublox GPS module. Works with most modules from Ublox including
+	from a u-blox GPS module. Works with most modules from u-blox including
 	the Zed-F9P, NEO-M8P-2, NEO-M9N, ZOE-M8Q, SAM-M8Q, and many others.
 
 	https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library
@@ -250,7 +250,7 @@ int SFE_UBLOX_GPS::transferReadI2C(u8_t *buffer, u32_t num_bytes)
 	return err;
 }
 
-//Changes the serial baud rate of the Ublox module, can't return success/fail 'cause ACK from modem
+//Changes the serial baud rate of the u-blox module, can't return success/fail 'cause ACK from modem
 //is lost due to baud rate change
 void SFE_UBLOX_GPS::setSerialRate(uint32_t baudrate, uint8_t uartPort, uint16_t maxWait)
 {
@@ -287,7 +287,7 @@ void SFE_UBLOX_GPS::setSerialRate(uint32_t baudrate, uint8_t uartPort, uint16_t 
     }
 }
 
-//Changes the I2C address that the Ublox module responds to
+//Changes the I2C address that the u-blox module responds to
 //0x42 is the default but can be changed with this command
 bool SFE_UBLOX_GPS::setI2CAddress(uint8_t deviceAddress, uint16_t maxWait)
 {
@@ -364,10 +364,10 @@ bool SFE_UBLOX_GPS::checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedClass
             uint8_t lsb = read_buffer[1];
             if (lsb == 0xFF)
             {
-                //I believe this is a Ublox bug. Device should never present an 0xFF.
+                //I believe this is a u-blox bug. Device should never present an 0xFF.
                 if ((_printDebug == true) || (_printLimitedDebug == true)) // Print this if doing limited debugging
                 {
-                    printk("checkUbloxI2C: Ublox bug, length lsb is 0xFF\n");
+                    printk("checkUbloxI2C: u-blox bug, length lsb is 0xFF\n");
                 }
                 if (checksumFailurePin >= 0)
                 {
@@ -462,7 +462,7 @@ bool SFE_UBLOX_GPS::checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedClass
                         {
                             if ((_printDebug == true) || (_printLimitedDebug == true)) // Print this if doing limited debugging
                             {
-                                printk("checkUbloxU2C: Ublox error, module not ready with data\n");
+                                printk("checkUbloxU2C: u-blox error, module not ready with data\n");
                             }
                             k_msleep(5); //In logic analyzation, the module starting responding after 1.48ms
                             if (checksumFailurePin >= 0)
@@ -1614,7 +1614,7 @@ bool SFE_UBLOX_GPS::factoryDefault(uint16_t maxWait)
 
 //Given a group, ID and size, return the value of this config spot
 //The 32-bit key is put together from group/ID/size. See other getVal to send key directly.
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::getVal8(uint16_t group, uint16_t id, uint8_t size, uint8_t layer, uint16_t maxWait)
 {
     //Create key
@@ -1634,7 +1634,7 @@ uint8_t SFE_UBLOX_GPS::getVal8(uint16_t group, uint16_t id, uint8_t size, uint8_
 //Given a key, return its value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -1693,7 +1693,7 @@ uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
 //Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
     return setVal16(key, value, layer, maxWait);
@@ -1702,7 +1702,7 @@ uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint1
 //Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -1734,7 +1734,7 @@ uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uin
 //Given a key, set an 8-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint16_t maxWait)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -1765,7 +1765,7 @@ uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint1
 //Given a key, set a 32-bit value
 //This function takes a full 32-bit key
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal32(uint32_t key, uint32_t value, uint8_t layer, uint16_t maxWait)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -1799,7 +1799,7 @@ uint8_t SFE_UBLOX_GPS::setVal32(uint32_t key, uint32_t value, uint8_t layer, uin
 //Start defining a new UBX-CFG-VALSET ubxPacket
 //This function takes a full 32-bit key and 32-bit value
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::newCfgValset32(uint32_t key, uint32_t value, uint8_t layer)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -1833,7 +1833,7 @@ uint8_t SFE_UBLOX_GPS::newCfgValset32(uint32_t key, uint32_t value, uint8_t laye
 //Start defining a new UBX-CFG-VALSET ubxPacket
 //This function takes a full 32-bit key and 16-bit value
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::newCfgValset16(uint32_t key, uint16_t value, uint8_t layer)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -1865,7 +1865,7 @@ uint8_t SFE_UBLOX_GPS::newCfgValset16(uint32_t key, uint16_t value, uint8_t laye
 //Start defining a new UBX-CFG-VALSET ubxPacket
 //This function takes a full 32-bit key and 8-bit value
 //Default layer is BBR
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::newCfgValset8(uint32_t key, uint8_t value, uint8_t layer)
 {
     packetCfg.cls = UBX_CLASS_CFG;
@@ -3150,7 +3150,7 @@ uint16_t SFE_UBLOX_GPS::getPDOP(uint16_t maxWait)
     return (pDOP);
 }
 
-//Get the current protocol version of the Ublox module we're communicating with
+//Get the current protocol version of the u-blox module we're communicating with
 //This is helpful when deciding if we should call the high-precision Lat/Long (HPPOSLLH) or the regular (POSLLH)
 uint8_t SFE_UBLOX_GPS::getProtocolVersionHigh(uint16_t maxWait)
 {
@@ -3159,7 +3159,7 @@ uint8_t SFE_UBLOX_GPS::getProtocolVersionHigh(uint16_t maxWait)
     return (versionHigh);
 }
 
-//Get the current protocol version of the Ublox module we're communicating with
+//Get the current protocol version of the u-blox module we're communicating with
 //This is helpful when deciding if we should call the high-precision Lat/Long (HPPOSLLH) or the regular (POSLLH)
 uint8_t SFE_UBLOX_GPS::getProtocolVersionLow(uint16_t maxWait)
 {
@@ -3168,7 +3168,7 @@ uint8_t SFE_UBLOX_GPS::getProtocolVersionLow(uint16_t maxWait)
     return (versionLow);
 }
 
-//Get the current protocol version of the Ublox module we're communicating with
+//Get the current protocol version of the u-blox module we're communicating with
 //This is helpful when deciding if we should call the high-precision Lat/Long (HPPOSLLH) or the regular (POSLLH)
 bool SFE_UBLOX_GPS::getProtocolVersion(uint16_t maxWait)
 {

--- a/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Library.h
+++ b/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/SparkFun_Ublox_Zephyr_Library.h
@@ -1,5 +1,5 @@
 /*
-	This is a library written for the Ublox ZED-F9P and NEO-M8P-2
+	This is a library written for the u-blox ZED-F9P and NEO-M8P-2
 	SparkFun sells these at its website: www.sparkfun.com
 	Do you like this library? Help support SparkFun. Buy a board!
 	https://www.sparkfun.com/products/15136
@@ -11,7 +11,7 @@
 	Written by Nathan Seidle @ SparkFun Electronics, September 6th, 2018
 
 	This library handles configuring and handling the responses
-	from a Ublox GPS module. Works with most modules from Ublox including
+	from a u-blox GPS module. Works with most modules from u-blox including
 	the Zed-F9P, NEO-M8P-2, NEO-M9N, ZOE-M8Q, SAM-M8Q, and many others.
 
 	https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library
@@ -143,9 +143,9 @@ const uint8_t UBX_CFG_SBAS = 0x16;		//SBAS configuration
 const uint8_t UBX_CFG_TMODE3 = 0x71;	//Time Mode Settings 3. Used to enable Survey In Mode
 const uint8_t UBX_CFG_TP5 = 0x31;		//Time Pulse Parameters
 const uint8_t UBX_CFG_USB = 0x1B;		//USB Configuration
-const uint8_t UBX_CFG_VALDEL = 0x8C;	//Used for config of higher version Ublox modules (ie protocol v27 and above). Deletes values corresponding to provided keys/ provided keys with a transaction
-const uint8_t UBX_CFG_VALGET = 0x8B;	//Used for config of higher version Ublox modules (ie protocol v27 and above). Configuration Items
-const uint8_t UBX_CFG_VALSET = 0x8A;	//Used for config of higher version Ublox modules (ie protocol v27 and above). Sets values corresponding to provided key-value pairs/ provided key-value pairs within a transaction.
+const uint8_t UBX_CFG_VALDEL = 0x8C;	//Used for config of higher version u-blox modules (ie protocol v27 and above). Deletes values corresponding to provided keys/ provided keys with a transaction
+const uint8_t UBX_CFG_VALGET = 0x8B;	//Used for config of higher version u-blox modules (ie protocol v27 and above). Configuration Items
+const uint8_t UBX_CFG_VALSET = 0x8A;	//Used for config of higher version u-blox modules (ie protocol v27 and above). Sets values corresponding to provided key-value pairs/ provided key-value pairs within a transaction.
 
 //The following are used to enable NMEA messages. Descriptions come from the NMEA messages overview in the ZED-F9P Interface Description
 const uint8_t UBX_NMEA_MSB = 0xF0;	//All NMEA enable commands have 0xF0 as MSB
@@ -482,8 +482,8 @@ public:
 	int transferWriteI2C(u8_t *buf, u32_t num_bytes, bool stop = true);	// Port to Zephyr, i2c function to actualy WRITE data
 	int transferReadI2C(u8_t *buf, u32_t num_bytes);					// Port to Zephyr, i2c function to actualy READ data
 
-	bool setI2CAddress(uint8_t deviceAddress, uint16_t maxTime = 250);										 //Changes the I2C address of the Ublox module
-	void setSerialRate(uint32_t baudrate, uint8_t uartPort = COM_PORT_UART1, uint16_t maxTime = defaultMaxWait); //Changes the serial baud rate of the Ublox module, uartPort should be COM_PORT_UART1/2
+	bool setI2CAddress(uint8_t deviceAddress, uint16_t maxTime = 250);										 //Changes the I2C address of the u-blox module
+	void setSerialRate(uint32_t baudrate, uint8_t uartPort = COM_PORT_UART1, uint16_t maxTime = defaultMaxWait); //Changes the serial baud rate of the u-blox module, uartPort should be COM_PORT_UART1/2
 	void setNMEAOutputPort();														 //Sets the internal variable for the port to direct NMEA characters to
 
 	bool setNavigationFrequency(uint8_t navFreq, uint16_t maxWait = defaultMaxWait);	 //Set the number of nav solutions sent per second

--- a/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/main.c
+++ b/examples/Zephyr/Example1_GetPositionAndTime_Zephyr/src/main.c
@@ -6,7 +6,7 @@
     License: MIT. See license file for more information but you can
     basically do whatever you want with this code.
 
-    This example reads the NMEA setences from the Ublox module over I2c and outputs
+    This example reads the NMEA setences from the u-blox module over I2c and outputs
     them to the serial port
 
     Open the serial monitor at 115200 baud to see the output
@@ -68,7 +68,7 @@ uint8_t init_i2c(void) {
 uint8_t init_gps(void) {
 	if (gps_begin(i2c_dev) != 0)
   	{
-    	printk("Ublox GPS init error!\n");
+    	printk("u-blox GPS init error!\n");
         return -1;
   	}
     return 0;
@@ -76,7 +76,7 @@ uint8_t init_gps(void) {
 
 
 void main(void) {
-	printk("Zephyr Ublox example\n");
+	printk("Zephyr u-blox example\n");
 
 	int err;
     err = init_gpio();

--- a/src/SparkFun_Ublox_Arduino_Library.cpp
+++ b/src/SparkFun_Ublox_Arduino_Library.cpp
@@ -3487,7 +3487,7 @@ sfe_ublox_status_e SFE_UBLOX_GPS::getVal(uint32_t key, uint8_t layer, uint16_t m
 //Given a key, return its value
 //This function takes a full 32-bit key
 //Default layer is RAM
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::getVal8(uint32_t key, uint8_t layer, uint16_t maxWait)
 {
   if (getVal(key, layer, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED)
@@ -3512,7 +3512,7 @@ uint32_t SFE_UBLOX_GPS::getVal32(uint32_t key, uint8_t layer, uint16_t maxWait)
 
 //Given a group, ID and size, return the value of this config spot
 //The 32-bit key is put together from group/ID/size. See other getVal to send key directly.
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::getVal8(uint16_t group, uint16_t id, uint8_t size, uint8_t layer, uint16_t maxWait)
 {
   uint32_t key = createKey(group, id, size);
@@ -3532,7 +3532,7 @@ uint32_t SFE_UBLOX_GPS::getVal32(uint16_t group, uint16_t id, uint8_t size, uint
 //Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is all: RAM+BBR+Flash
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
   return setVal16(key, value, layer, maxWait);
@@ -3541,7 +3541,7 @@ uint8_t SFE_UBLOX_GPS::setVal(uint32_t key, uint16_t value, uint8_t layer, uint1
 //Given a key, set a 16-bit value
 //This function takes a full 32-bit key
 //Default layer is all: RAM+BBR+Flash
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -3573,7 +3573,7 @@ uint8_t SFE_UBLOX_GPS::setVal16(uint32_t key, uint16_t value, uint8_t layer, uin
 //Given a key, set an 8-bit value
 //This function takes a full 32-bit key
 //Default layer is all: RAM+BBR+Flash
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
@@ -3604,7 +3604,7 @@ uint8_t SFE_UBLOX_GPS::setVal8(uint32_t key, uint8_t value, uint8_t layer, uint1
 //Given a key, set a 32-bit value
 //This function takes a full 32-bit key
 //Default layer is all: RAM+BBR+Flash
-//Configuration of modern Ublox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
+//Configuration of modern u-blox modules is now done via getVal/setVal/delVal, ie protocol v27 and above found on ZED-F9P
 uint8_t SFE_UBLOX_GPS::setVal32(uint32_t key, uint32_t value, uint8_t layer, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;


### PR DESCRIPTION
Hi @PaulZC,

This PR for the v2.0 candidate includes a couple of minor changes:

1) I've replaced all instances of the `//http://librarymanager/All#SparkFun_Ublox_GPS` helper link with `//http://librarymanager/All#SparkFun_u-blox_GPS`

2) As part of our constant efforts to please the OCD gods (@nseidle may appreciate this), I've attempted to replace all instances of "Ublox" with "u-blox" contained in comments and/or print commands for the entire library.

I also manually reviewed all the changes to ensure I hadn't accidentally changed any instances of "Ublox" that were actually operational code.

Cheers,
Adam